### PR TITLE
use correct date in sidebar

### DIFF
--- a/layouts/partials/site-sidebar.html
+++ b/layouts/partials/site-sidebar.html
@@ -10,7 +10,7 @@
       </section>
       <header>
         <h1><a href="{{ .RelPermalink }}">{{ .Title }}</a></h1>
-        <time class="published" datetime="">{{ default (i18n "date_format") }}</time>
+        <time class="published" datetime="">{{ default (i18n "date_format") | .Date.Format }}</time>
       </header>
     </article>
     {{ end }}


### PR DESCRIPTION
## Description

In the sidebar, the date of recent posts was always January 2, 2006. This PR fixes that, such that the correct date of the post is used.

## Motivation and Context

Dates are different from the real dates of a post.

## How Has This Been Tested?

Did the change on my blog.

## Screenshots (if appropriate):

![Screenshot_2019-05-08 Shiny Adventures - Frederik Hahne's Blog](https://user-images.githubusercontent.com/203401/57351018-9c06c800-7160-11e9-9f53-e45b63d4df40.png)

## Types of changes

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x ] My code follows the [code style] of this project.
- [ ] My change requires a change to the [documentation].
- [ ] I have updated the documentation, including `theme.toml`, accordingly.
- [ x] I have read the [Contributing Document].

[Code Style]: https://github.com/pacollins/hugo-future-imperfect-slim/blob/master/.github/CONTRIBUTING.md#Style-Guide
[Contributing Document]: https://github.com/pacollins/hugo-future-imperfect-slim/blob/master/.github/CONTRIBUTING.md
[Documentation]: https://github.com/pacollins/hugo-future-imperfect-slim/wiki
