### PR TITLE
Additional languages for highlight.js would not be loaded.

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,16 @@ Hugo will build your site and host a server locally. You can view this live at
 In addition to the native [Hugo shortcodes](https://gohugo.io/extras/shortcodes/),
 the theme also includes additional shortcodes that you may find useful.
 
+## Source Code Highlighting
+
+You can enable source code hightlighting via [highlight.js](https://highlightjs.org).
+If you want to use a language which is not in the [common package](https://highlightjs.org/download/) of highlight.js
+you can enable that language via `highlightjsLang` and the additional packages with be added to your site.
+
+```
+highlightjsLang=["yaml", "groovy"]
+```
+
 ## About the Author
 
 [Hugo Future Imperfect](http://html5up.net/future-imperfect) is a theme by

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,7 +1,7 @@
 {{ if .Site.Params.highlightjs }}
   <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/highlight.min.js"></script>
-  {{ range .Params.highlightjsLang }}<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/{{ . }}.min.js"></script>{{ end }}
-  <script>hljs.configure({languages: []}); hljs.initHighlightingOnLoad();</script>
+  {{ range Site.Params.highlightjsLang }}<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/languages/{{ . }}.min.js"></script>{{ end }}
+  <script>hljs.initHighlightingOnLoad();</script>
 {{ end }}
 {{ range .Site.Params.jsFiles }}
   {{ if eq . "default" }}
@@ -15,5 +15,4 @@
     <script src="{{ . | relURL }}"></script>
   {{ end }}
 {{ end }}
-<script>hljs.initHighlightingOnLoad();</script>
 {{ template "_internal/google_analytics_async.html" . }}


### PR DESCRIPTION
Additional languages for highlight.js would not be loaded.

## Description

Additional languages for highlight.js would not be loaded, because the wrong parameter was read and the url was not correct. `hljs.initHighlightingOnLoad();` was called even in case it was disabled in .toml configuration.

## Motivation and Context

I added gradle and yaml as language and they were not highlighted.

## How Has This Been Tested?

I did the same changes on my personal block. See this post for example: https://atomfrede.gitlab.io/2019/05/jhipster-with-testcontainers/

**Hugo Version:**

`v0.55.5`

**Browser(s):**

* Not relevant

## Screenshots (if appropriate):

`yaml` is now highlighted:

![Screenshot_2019-05-19 JHipster With Testcontainers](https://user-images.githubusercontent.com/203401/57983326-a96d5d80-7a50-11e9-97ca-565a3502ccd7.png)

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the [code style] of this project.
- [ ] My change requires a change to the [documentation].
- [x] I have updated the documentation, including `theme.toml`, accordingly.
- [x] I have read the [Contributing Document].

[Code Style]: https://github.com/pacollins/hugo-future-imperfect-slim/blob/master/.github/CONTRIBUTING.md#Style-Guide
[Contributing Document]: https://github.com/pacollins/hugo-future-imperfect-slim/blob/master/.github/CONTRIBUTING.md
[Documentation]: https://github.com/pacollins/hugo-future-imperfect-slim/wiki
