### PR TITLE
Disable recent posts when set 0

### DIFF
--- a/layouts/partials/site-sidebar.html
+++ b/layouts/partials/site-sidebar.html
@@ -1,23 +1,25 @@
 <section id="site-sidebar">
-  <section id="recent-posts">
-    <header>
-      <h1>{{ i18n "recent_posts" }}</h1>
-    </header>
-    {{ range first (.Site.Params.sidebar.postAmount | default 5) (where .Site.Pages  "Type" "post") }}
-    <article class="mini-post">
-      <section>
-        {{ .Render "featured" }}
-      </section>
+  {{ if gt .Site.Params.sidebar.postAmount 0 }}
+    <section id="recent-posts">
       <header>
-        <h1><a href="{{ .RelPermalink }}">{{ .Title }}</a></h1>
-        <time class="published" datetime="">{{ default (i18n "date_format") | .Date.Format }}</time>
+        <h1>{{ i18n "recent_posts" }}</h1>
       </header>
-    </article>
-    {{ end }}
-    {{ if ge (len (where .Site.Pages "Type" "post")) (.Site.Params.sidebar.postAmount | default 5) }}
-      <a href="{{ with .Site.Params.viewMorePostsLink }}{{ . | relLangURL }}{{ else }}{{ "post" | relLangURL }}{{ end }}" class="button">{{ i18n "see_more" }}</a>
-    {{ end }}
-  </section>
+      {{ range first (.Site.Params.sidebar.postAmount | default 5) (where .Site.Pages  "Type" "post") }}
+      <article class="mini-post">
+        <section>
+          {{ .Render "featured" }}
+        </section>
+        <header>
+          <h1><a href="{{ .RelPermalink }}">{{ .Title }}</a></h1>
+          <time class="published" datetime="">{{ default (i18n "date_format") | .Date.Format }}</time>
+        </header>
+      </article>
+      {{ end }}
+      {{ if ge (len (where .Site.Pages "Type" "post")) (.Site.Params.sidebar.postAmount | default 5) }}
+        <a href="{{ with .Site.Params.viewMorePostsLink }}{{ . | relLangURL }}{{ else }}{{ "post" | relLangURL }}{{ end }}" class="button">{{ i18n "see_more" }}</a>
+      {{ end }}
+    </section>
+  {{ end }}
 
   {{ if .Site.Params.sidebar.categories }}
     {{ if ne ($.Scratch.Get "showCategories") false }}


### PR DESCRIPTION
<!--- Prerequisites -->
<!--- I am running the latest version of [Hugo](https://github.com/gohugoio/hugo/releases) -->
<!--- I am using the latest version of [Hugo-Future-Imperfect](https://github.com/pacollins/hugo-future-imperfect-slim/releases) -->
<!--- I checked the [issues](https://github.com/pacollins/hugo-future-imperfect-slim/issues?utf8=%E2%9C%93&q=is%3Aissue) to make sure that this feature has not been rejected before -->
<!--- I checked the [pull requests](https://github.com/pacollins/hugo-future-imperfect-slim/pulls?utf8=%E2%9C%93&q=is%3Apr) to make sure that this feature is not already being developed -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

`If gt postAmount 0` enable `Recent Posts` section. I am not sold that this is the best way to do this, but it is functional. I would like a second opinion first.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here with "Closes #XXX" -->

Closes #20 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

**Hugo Version:** 0.50

**Browser(s):** Chrome

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the [code style] of this project.
- [ ] My change requires a change to the [documentation].
- [ ] I have updated the documentation, including `theme.toml`, accordingly.
- [X] I have read the [Contributing Document].

[Code Style]: https://github.com/pacollins/hugo-future-imperfect-slim/blob/master/.github/CONTRIBUTING.md#Style-Guide
[Contributing Document]: https://github.com/pacollins/hugo-future-imperfect-slim/blob/master/.github/CONTRIBUTING.md
[Documentation]: https://github.com/pacollins/hugo-future-imperfect-slim/wiki
