### PR TITLE
micro fix - typo (parameter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ you will also need to copy _staticman.yml_.
 
 This file is important to the initial set-up of your project and contains all of
 the customizations that the developers feel as though you should have easy access
-to. Each prarameter listed should include a comment to help describe it's function.
+to. Each parameter listed should include a comment to help describe it's function.
 Unless otherwise state, _true_ will turn a feature **on**, while _false_ will turn
 a feature **off**. It is structured as follows:
 


### PR DESCRIPTION
<!---
  ## Prerequisites
  - I am running the latest version of [Hugo](https://github.com/gohugoio/hugo/releases)
  - I am using the latest version of [Hugo-Future-Imperfect-slim](https://github.com/pacollins/hugo-future-imperfect-slim/releases)
  - I checked the [issues](https://github.com/pacollins/hugo-future-imperfect-slim/issues?utf8=%E2%9C%93&q=is%3Aissue) to make sure that this feature has not been rejected before
  - I checked the [pull requests](https://github.com/pacollins/hugo-future-imperfect-slim/pulls?utf8=%E2%9C%93&q=is%3Apr) to make sure that this feature is not already being developed
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Just a micro typo fix of the word `parameter`



## Motivation and Context
This same Readme seems to get reflected in the Hugo page too so thought of submitting a fix 


## Screenshots (if appropriate):

<!-- ![Screenshot](IMGURL) -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation Typo
## Checklist:
<!---
  Please review the following points and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [Contributing Document](https://github.com/pacollins/hugo-future-imperfect-slim/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the [code style](https://github.com/pacollins/hugo-future-imperfect-slim/blob/master/.github/CONTRIBUTING.md#Style-Guide) of this project.
- [x] My change requires a change to the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki).
- [x] I have updated the documentation, including `theme.toml`, accordingly.
