### PR TITLE
Fixes comments.html to respect the staticman boolean in [params.staticman]

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -87,14 +87,12 @@ disableLanguages        = [""]
 
   # Disqus will take priority over Staticman (github.com/eduardoboucas/staticman)
   # due to its ease of use. Feel free to check out both and decide which you would
-  # prefer to use. See Staticman.yml for additional settings.
+  # prefer to use. See staticman.yml for additional settings.
   [params.staticman]
-    # Sets Statiman to be active
     # If using GitHub, go to https://github.com/apps/staticman-net
     # If using GitLab, just add the GitLab bot, NO need to hit `/connect/v3/...`
-    staticman           = false
-    # Sets the location for Staticman to connect to
-    api                 = "dev.staticman.net"  # without trailing slash
+    enabled             = false
+    api                 = ""  # without trailing slash, defaults to "api.staticman.net"
     gitProvider         = "github"  # either "github" or "gitlab"
     username            = ""
     repo                = ""

--- a/layouts/post/comments.html
+++ b/layouts/post/comments.html
@@ -2,7 +2,7 @@
     <article class="post">
         {{ template "_internal/disqus.html" . }}
     </article>
-{{ else if .Site.Params.staticman }}
+{{ else if .Site.Params.staticman.staticman }}
     <article class="post">
       {{ .Render "staticman" }}
     </article>

--- a/layouts/post/comments.html
+++ b/layouts/post/comments.html
@@ -2,7 +2,9 @@
     <article class="post">
         {{ template "_internal/disqus.html" . }}
     </article>
-{{ else if .Site.Params.staticman.staticman }}
+
+{{/* Backwards compatibility for deprecated parameter ".Site.Params.staticman.staticman" */}}
+{{ else if or .Site.Params.staticman.enabled .Site.Params.staticman.staticman }}
     <article class="post">
       {{ .Render "staticman" }}
     </article>

--- a/layouts/post/staticman.html
+++ b/layouts/post/staticman.html
@@ -1,6 +1,6 @@
 <h2>Say something</h2>
 {{ with .Site.Params.staticman }}
-  <form class="post-new-comment" method="POST" action="https://{{ .api }}/v3/entry/{{ .gitprovider }}/{{ .username }}/{{ .repo }}/{{ .branch }}/comments">
+  <form class="post-new-comment" method="POST" action="https://{{ .api | default "api.staticman.net" }}/v3/entry/{{ .gitprovider }}/{{ .username }}/{{ .repo }}/{{ .branch }}/comments">
 {{ end }}
     <input type="hidden" name="options[redirect]" value="{{ .Permalink }}">
     <input type="hidden" name="options[entryId]" value="{{ .File.UniqueID }}">


### PR DESCRIPTION
## Description

Changes the reference to the staticman boolean from `.Site.Params.staticman` to `.Site.Params.staticman.staticman`.

## Motivation and Context

This change addresses issue #59 and fixes comments.html to respect the staticman boolean in [params.staticman].

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have read the [Contributing Document](https://github.com/pacollins/hugo-future-imperfect-slim/blob/master/.github/CONTRIBUTING.md).
- [X] My code follows the [code style](https://github.com/pacollins/hugo-future-imperfect-slim/blob/master/.github/CONTRIBUTING.md#Style-Guide) of this project.
- [ ] My change requires a change to the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki).
- [ ] I have updated the documentation, including `theme.toml`, accordingly.
