### PR TITLE
Fixed config evaluation for include of staticman.js

### DIFF
--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -18,7 +18,7 @@
 {{/* Backwards compatibility for deprecated parameter ".Site.Params.staticman.staticman" */}}
 {{ if or .Site.Params.staticman.enabled .Site.Params.staticman.staticman }}
   {{- $smjs := resources.Get "js/staticman.js" | resources.ExecuteAsTemplate "js/staticman.js" .Site.Params.staticman -}}
-    <script src='{{ $smjs.RelPermalink }}'></script>
+  <script src='{{ $smjs.RelPermalink }}'></script>
   {{ if and .Site.Params.staticman.recaptcha.siteKey .Site.Params.staticman.recaptcha.encryptedKey }}
     <script src='https://www.google.com/recaptcha/api.js'></script>
   {{ end }}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -15,9 +15,10 @@
     <script src="{{ . | relURL }}"></script>
   {{ end }}
 {{ end }}
-{{ if .Site.Params.staticman }}
+{{/* Backwards compatibility for deprecated parameter ".Site.Params.staticman.staticman" */}}
+{{ if or .Site.Params.staticman.enabled .Site.Params.staticman.staticman }}
   {{- $smjs := resources.Get "js/staticman.js" | resources.ExecuteAsTemplate "js/staticman.js" .Site.Params.staticman -}}
-  <script src='{{ $smjs.RelPermalink }}'></script>
+    <script src='{{ $smjs.RelPermalink }}'></script>
   {{ if and .Site.Params.staticman.recaptcha.siteKey .Site.Params.staticman.recaptcha.encryptedKey }}
     <script src='https://www.google.com/recaptcha/api.js'></script>
   {{ end }}


### PR DESCRIPTION
## Description
Currently, `staticman.js` is included/loaded, no matter if staticman is activated or not. In `script.html` is a check for `.Site.Params.staticman` which should be `.Site.Params.staticman.enabled` resp. `.Site.Params.staticman.staticman`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!---
  Please review the following points and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [Contributing Document](https://github.com/pacollins/hugo-future-imperfect-slim/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the [code style](https://github.com/pacollins/hugo-future-imperfect-slim/blob/master/.github/CONTRIBUTING.md#Style-Guide) of this project.
- [ ] My change requires a change to the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki).
- [ ] I have updated the documentation, including `theme.toml`, accordingly.
