### PR TITLE
Allow and configure hiding the intro on mobile pages

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1529,7 +1529,7 @@ textarea {
    }
  }
 
- #site-intro.hidden-on-mobile {
+ #site-intro.hidden-single-column {
    display: none;
 
    @include for-desktop-up {

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1529,6 +1529,14 @@ textarea {
    }
  }
 
+ #site-intro.hidden-on-mobile {
+   display: none;
+
+   @include for-desktop-up {
+     display: flex;
+   }
+ }
+
  /* Site Main */
 
  #site-main {

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -61,6 +61,10 @@ disableLanguages        = [""]
     paragraph             = "Another fine, responsive site template by <a href='http://html5up.net'>HTML5 UP</a>."
     rssIntro              = true
     socialIntro           = true
+    # You may not want to display a long intro above content on small screens.
+    hideOnMobile          = true
+    # But you may want to always display the intro on the homepage.
+    alwaysOnHomepage      = true
 
     # This appears at the top of the sidebar above params.intro.header.
     # A width of less than 100px is recommended from a design perspective.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -62,9 +62,9 @@ disableLanguages        = [""]
     rssIntro              = true
     socialIntro           = true
     # You may not want to display a long intro above content on small screens.
-    hideOnMobile          = true
+    hideOnMobile          = false
     # But you may want to always display the intro on the homepage.
-    alwaysOnHomepage      = true
+    alwaysOnHomepage      = false
 
     # This appears at the top of the sidebar above params.intro.header.
     # A width of less than 100px is recommended from a design perspective.

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -61,8 +61,9 @@ disableLanguages        = [""]
     paragraph             = "Another fine, responsive site template by <a href='http://html5up.net'>HTML5 UP</a>."
     rssIntro              = true
     socialIntro           = true
-    # You may not want to display a long intro above content on small screens.
-    hideOnMobile          = false
+    # You may not want to display a long intro above content in the
+    # single column layout used on smaller screens.
+    hideWhenSingleColumn  = false
     # But you may want to always display the intro on the homepage.
     alwaysOnHomepage      = false
 

--- a/layouts/partials/site-intro.html
+++ b/layouts/partials/site-intro.html
@@ -1,4 +1,4 @@
-<section id="site-intro" {{ if (and (.Site.Params.intro.hideOnMobile) (not (and .Page.IsHome .Site.Params.intro.alwaysOnHomepage))) }}class="hidden-on-mobile"{{ end }}>
+<section id="site-intro" {{ if (and (.Site.Params.intro.hideWhenSingleColumn) (not (and .Page.IsHome .Site.Params.intro.alwaysOnHomepage))) }}class="hidden-single-column"{{ end }}>
   {{ with .Site.Params.intro.pic }}<a href="{{ "/" | relLangURL}}"><img src="{{ .src | relURL }}" class="{{ .shape }}" width="{{ .width }}" alt="{{ .alt }}" /></a>{{ end }}
   <header>
     {{ with .Site.Params.intro.header }}<h1>{{ . | safeHTML }}</h1>{{ end }}

--- a/layouts/partials/site-intro.html
+++ b/layouts/partials/site-intro.html
@@ -1,4 +1,4 @@
-<section id="site-intro">
+<section id="site-intro" {{ if (and (.Site.Params.intro.hideOnMobile) (not (and .Page.IsHome .Site.Params.intro.alwaysOnHomepage))) }}class="hidden-on-mobile"{{ end }}>
   {{ with .Site.Params.intro.pic }}<a href="{{ "/" | relLangURL}}"><img src="{{ .src | relURL }}" class="{{ .shape }}" width="{{ .width }}" alt="{{ .alt }}" /></a>{{ end }}
   <header>
     {{ with .Site.Params.intro.header }}<h1>{{ . | safeHTML }}</h1>{{ end }}


### PR DESCRIPTION
<!---
  ## Prerequisites
  - I am running the latest version of [Hugo](https://github.com/gohugoio/hugo/releases)
  - I am using the latest version of [Hugo-Future-Imperfect-slim](https://github.com/pacollins/hugo-future-imperfect-slim/releases)
  - I checked the [issues](https://github.com/pacollins/hugo-future-imperfect-slim/issues?utf8=%E2%9C%93&q=is%3Aissue) to make sure that this feature has not been rejected before
  - I checked the [pull requests](https://github.com/pacollins/hugo-future-imperfect-slim/pulls?utf8=%E2%9C%93&q=is%3Apr) to make sure that this feature is not already being developed
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This commit adds css, and template logic to hide the intro on mobile devices (when in linear layout and not grid layout) for pages that are not the homepage.

I added configuration parameters to config.toml to configure if it is always hidden on mobile, never hidden on mobile, or only hidden on pages that are not the homepage. I used two boolean config parameters, which does create a fourth redundant state where `hideOnMobile = false` and `alwaysOnHomepage = true` leads to the same outcome as `hideOnMobile = false` and `alwaysOnHomepage = false`. This configuration could be changed to some kind of state enum if people think that would be better, at the expense of the logic getting a little more complicated in the template.

## Motivation and Context
<!---
  Why is this change required? What problem does it solve?
  If it fixes an open issue, please link to the issue here by writing "Closes #XXX"
-->

The intro section can be quite long, especially when a picture is enabled. See the screenshots below for examples. By default the intro appears on the left on computer screen sizes, but above the content on mobile devices. Before this change the intro appeared on every page, even the detailed pages of specific blog posts. 

## Screenshots:

<!-- ![Screenshot](IMGURL) -->

### Current desktop layout of a post (or content list)
The desktop layout has a nice grid structure with the intro and post content visible at the same time. The proposed PR does not change this layout at all.

![Grid Layout](https://user-images.githubusercontent.com/22477941/72959576-9e956600-3d5f-11ea-910a-89bcd078d5f8.png)

### Current mobile layout of a post (or content list)
Note the redundant intro that users have likely already seen taking up a large fraction of the screen

![linear layout](https://user-images.githubusercontent.com/22477941/72959653-e916e280-3d5f-11ea-8642-aeaef2969ee1.png)

### Proposed mobile layout change
This PR proposes allowing users to hide the intro block on mobile pages if they desire. This lets the post page lead with post content rather than the redundant intro. As currently implemented the intro will be hidden both on post detail pages and "deeper" site list pages like the list of blog posts or the list of categories.
![linear layout without intro](https://user-images.githubusercontent.com/22477941/72959689-0946a180-3d60-11ea-80c0-860a69084d32.png)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!---
  Please review the following points and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] I have read the [Contributing Document](https://github.com/pacollins/hugo-future-imperfect-slim/blob/master/.github/CONTRIBUTING.md).
- [x] My code follows the [code style](https://github.com/pacollins/hugo-future-imperfect-slim/blob/master/.github/CONTRIBUTING.md#Style-Guide) of this project.
- [x] My change requires a change to the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki).
- [x] I have updated the documentation, including `theme.toml`, accordingly.
