### PR TITLE
Update pluralisation for more than 1 minute read

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -2,7 +2,7 @@
   other = "January 2, 2006"
 [postreadingtime]
   one = "1 minute read"
-  other = "{{ .Count }} minutes read"
+  other = "{{ .Count }} minute read"
 [recent_posts]
   other = "Recent posts"
 [see_more]


### PR DESCRIPTION
<!---
  ## Prerequisites
  - I am running the latest version of [Hugo](https://github.com/gohugoio/hugo/releases)
  - I am using the latest version of [Hugo-Future-Imperfect-slim](https://github.com/pacollins/hugo-future-imperfect-slim/releases)
  - I checked the [issues](https://github.com/pacollins/hugo-future-imperfect-slim/issues?utf8=%E2%9C%93&q=is%3Aissue) to make sure that this feature has not been rejected before
  - I checked the [pull requests](https://github.com/pacollins/hugo-future-imperfect-slim/pulls?utf8=%E2%9C%93&q=is%3Apr) to make sure that this feature is not already being developed
-->

<!--- Provide a general summary of your changes in the Title above -->

## Description
There's no need to pluralise minutes when showing how many minutes reading time an article is. It should display:
"12 minute read"
instead of
"12 minutes read"

## Motivation and Context
Update grammar for English localisation

## Types of changes


- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!---
  Please review the following points and put an `x` in all the boxes that apply.
  If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [X] I have read the [Contributing Document](https://github.com/pacollins/hugo-future-imperfect-slim/blob/master/.github/CONTRIBUTING.md).
- [X] My code follows the [code style](https://github.com/pacollins/hugo-future-imperfect-slim/blob/master/.github/CONTRIBUTING.md#Style-Guide) of this project.
- [ ] My change requires a change to the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki).
- [ ] I have updated the documentation, including `theme.toml`, accordingly.
