### PR TITLE
Remove duplicate variable social.strava

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -307,7 +307,6 @@ disableLanguages        = [""]
   twitter               = "example"
   strava                = ""
   skype                 = ""
-  strava                = ""
   snapchat              = ""
   pinterest             = "example"
   telegram              = "example"


### PR DESCRIPTION
After copying the sample config.toml to a new site, I get error

    Key 'social.strava' has already been defined.

Removing this line fixes the error.

