### PR TITLE
flex wrap on comment paragraphs

### DIFF
--- a/assets/js/staticman.js
+++ b/assets/js/staticman.js
@@ -97,7 +97,7 @@ $(document).ready(function() {
   });
 
   // handle removal of reply target when '×' is pressed
-  $('.new-comment .reply-notice').on('click', '.post-reply-close-btn', function(){
+  $('.new-comment .reply-notice').on('click', '.reply-close-btn', function(){
     resetReplyTarget();
   });
 

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1461,35 +1461,34 @@ figcaption {
     @include for-mobile-l-up {
       border-radius: 0;
     }
+    div {
+      @include display-flex;
+      flex-direction: column;
+      flex-grow: 1;
+      align-items: center;
+      @include for-mobile-l-up {
+        flex-direction: row;
+      }
+      .comment-author-container {
+        @include display-flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        @include for-mobile-l-up {
+          align-items: flex-start;
+          flex-grow: 1;
+        }
+        @include for-laptop-up {
+          flex-direction: row;
+          align-items: center;
+        }
+      }
+    }
   }
   &.comment-reply {
     margin-left: $avatar-size/2;
     @include for-mobile-l-up {
       margin-left: $avatar-size;
-    }
-  }
-  div {
-    @include display-flex;
-    flex-direction: column;
-    flex-grow: 1;
-    flex-wrap: wrap;
-    align-items: center;
-    @include for-mobile-l-up {
-      flex-direction: row;
-    }
-    .comment-author-container {
-      @include display-flex;
-      flex-direction: column;
-      align-items: center;
-      text-align: center;
-      @include for-mobile-l-up {
-        align-items: flex-start;
-        flex-grow: 1;
-      }
-      @include for-laptop-up {
-        flex-direction: row;
-        align-items: center;
-      }
     }
   }
 }

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1472,6 +1472,7 @@ figcaption {
     @include display-flex;
     flex-direction: column;
     flex-grow: 1;
+    flex-wrap: wrap;
     align-items: center;
     @include for-mobile-l-up {
       flex-direction: row;

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1469,20 +1469,6 @@ figcaption {
       @include for-mobile-l-up {
         flex-direction: row;
       }
-      .comment-author-container {
-        @include display-flex;
-        flex-direction: column;
-        align-items: center;
-        text-align: center;
-        @include for-mobile-l-up {
-          align-items: flex-start;
-          flex-grow: 1;
-        }
-        @include for-laptop-up {
-          flex-direction: row;
-          align-items: center;
-        }
-      }
     }
   }
   &.comment-reply {
@@ -1490,6 +1476,21 @@ figcaption {
     @include for-mobile-l-up {
       margin-left: $avatar-size;
     }
+  }
+}
+
+.comment-author-container {
+  @include display-flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  @include for-mobile-l-up {
+    align-items: flex-start;
+    flex-grow: 1;
+  }
+  @include for-laptop-up {
+    flex-direction: row;
+    align-items: center;
   }
 }
 


### PR DESCRIPTION
## Description

When comments have multiple p tags, the flex was putting them all in the same row.

## Motivation and Context

adding `flex-wrap: wrap;` to `.comment div` resolves this.

## Screenshots (if appropriate):

Here's the problem: 

![Screenshot_20200723_115532](https://user-images.githubusercontent.com/632682/88327461-ee87c200-ccdb-11ea-9138-29153014a5a9.png)


## Checklist:

n/a

- [ ] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [ ] I have updated the `theme.toml`, as applicable.
