### PR TITLE
New boolean param for user to choose to hide empty stats

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -27,7 +27,7 @@ disableLanguages        = []
   readingTime           = true
   imageStretch          = ""
   socialShare           = ["twitter", "facebook", "reddit", "linkedin", "pinterest", "email"]
-  hideEmptyStats        = true # if no Category or no Tag, hide it
+  hideEmptyStats        = false
 
   [params.meta]
     description         = "A theme by HTML5 UP, ported by Julio Pescador. Slimmed and enhanced by Patrick Collins. Multilingual by StatnMap. Powered by Hugo."

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -27,6 +27,7 @@ disableLanguages        = []
   readingTime           = true
   imageStretch          = ""
   socialShare           = ["twitter", "facebook", "reddit", "linkedin", "pinterest", "email"]
+  hideEmptyStats        = true # if no Category or no Tag, hide it
 
   [params.meta]
     description         = "A theme by HTML5 UP, ported by Julio Pescador. Slimmed and enhanced by Patrick Collins. Multilingual by StatnMap. Powered by Hugo."

--- a/layouts/_default/stats.html
+++ b/layouts/_default/stats.html
@@ -1,5 +1,5 @@
 <div class="stats">
-  {{ if (isset .Params "categories") }}
+  {{ if .Params.categories }}
     <ul class="categories">
       {{ if gt (len .Params.categories) 0 }}
         {{ range .Params.categories }}
@@ -13,7 +13,7 @@
       <li>None</li>
     </ul>
   {{ end }}
-  {{ if (isset .Params "tags") }}
+  {{ if .Params.tags }}
     <ul class="tags">
       {{ if gt (len .Params.tags) 0 }}
         {{ range .Params.tags }}

--- a/layouts/_default/stats.html
+++ b/layouts/_default/stats.html
@@ -1,5 +1,5 @@
 <div class="stats">
-  {{ if or (and (eq .Site.Params.hideEmptyStats true) (isset .Params "categories")) (and (eq .Site.Params.hideEmptyStats false) (isset .Params "categories")) }}
+  {{ if (isset .Params "categories") }}
     <ul class="categories">
       {{ if gt (len .Params.categories) 0 }}
         {{ range .Params.categories }}
@@ -7,13 +7,13 @@
         {{ end }}
       {{ end }}
     </ul>
-  {{ else if and (eq .Site.Params.hideEmptyStats true) (not (isset .Params "categories")) }}
-  {{ else if and (eq .Site.Params.hideEmptyStats false) (not (isset .Params "categories")) }}
+  {{ else if .Site.Params.hideEmptyStats }}
+  {{ else }}
     <ul class="categories">
       <li>None</li>
     </ul>
   {{ end }}
-  {{ if or (and (eq .Site.Params.hideEmptyStats true) (isset .Params "tags")) ( and (eq .Site.Params.hideEmptyStats false) (isset .Params "tags")) }}
+  {{ if (isset .Params "tags") }}
     <ul class="tags">
       {{ if gt (len .Params.tags) 0 }}
         {{ range .Params.tags }}
@@ -21,8 +21,8 @@
         {{ end }}
       {{ end }}
     </ul>
-  {{ else if and (eq .Site.Params.hideEmptyStats true) (not (isset .Params "tags")) }}
-  {{ else if and (eq .Site.Params.hideEmptyStats false) (not (isset .Params "tags")) }}
+  {{ else if .Site.Params.hideEmptyStats }}
+  {{ else }}
     <ul class="tags">
       <li>None</li>
     </ul>

--- a/layouts/_default/stats.html
+++ b/layouts/_default/stats.html
@@ -1,8 +1,8 @@
 <div class="stats">
   {{ if .Params.categories }}
     <ul class="categories">
-      {{ if gt (len .Params.categories) 0 }}
-        {{ range .Params.categories }}
+      {{ with .Params.categories }}
+        {{ range . }}
           <li><a class="article-terms-link" href="{{ path.Join "categories" (. | urlize | lower) | relLangURL }}/">{{ . }}</a></li>
         {{ end }}
       {{ end }}
@@ -15,8 +15,8 @@
   {{ end }}
   {{ if .Params.tags }}
     <ul class="tags">
-      {{ if gt (len .Params.tags) 0 }}
-        {{ range .Params.tags }}
+      {{ with .Params.tags }}
+        {{ range . }}
           <li><a class="article-terms-link" href="{{ path.Join "tags" (. | urlize | lower) | relLangURL }}/">{{ . }}</a></li>
         {{ end }}
       {{ end }}

--- a/layouts/_default/stats.html
+++ b/layouts/_default/stats.html
@@ -1,24 +1,30 @@
 <div class="stats">
-  <ul class="categories">
-    {{ if isset .Params "categories" }}
+  {{ if or (and (eq .Site.Params.hideEmptyStats true) (isset .Params "categories")) (and (eq .Site.Params.hideEmptyStats false) (isset .Params "categories")) }}
+    <ul class="categories">
       {{ if gt (len .Params.categories) 0 }}
         {{ range .Params.categories }}
           <li><a class="article-terms-link" href="{{ path.Join "categories" (. | urlize | lower) | relLangURL }}/">{{ . }}</a></li>
         {{ end }}
       {{ end }}
-    {{ else }}
+    </ul>
+  {{ else if and (eq .Site.Params.hideEmptyStats true) (not (isset .Params "categories")) }}
+  {{ else if and (eq .Site.Params.hideEmptyStats false) (not (isset .Params "categories")) }}
+    <ul class="categories">
       <li>None</li>
-    {{ end }}
-  </ul>
-  <ul class="tags">
-    {{ if isset .Params "tags" }}
+    </ul>
+  {{ end }}
+  {{ if or (and (eq .Site.Params.hideEmptyStats true) (isset .Params "tags")) ( and (eq .Site.Params.hideEmptyStats false) (isset .Params "tags")) }}
+    <ul class="tags">
       {{ if gt (len .Params.tags) 0 }}
         {{ range .Params.tags }}
           <li><a class="article-terms-link" href="{{ path.Join "tags" (. | urlize | lower) | relLangURL }}/">{{ . }}</a></li>
         {{ end }}
       {{ end }}
-    {{ else }}
+    </ul>
+  {{ else if and (eq .Site.Params.hideEmptyStats true) (not (isset .Params "tags")) }}
+  {{ else if and (eq .Site.Params.hideEmptyStats false) (not (isset .Params "tags")) }}
+    <ul class="tags">
       <li>None</li>
-    {{ end }}
-  </ul>
+    </ul>
+  {{ end }}
 </div>


### PR DESCRIPTION
## Description

Adds logic to the stats file to hide stats, based on user preference, when two conditions are met: user prefers to hide them, and they are empty.

This logic had to be more complex (or busy-looking) than I originally envisioned. But this is the best I could come up with. The logic is way simpler when you simply enable this functionality, without giving the user a choice.

## Motivation and Context

Currently, If a Tag or Category isn't populated, the icon is displayed and it says "None". This seems like noise to me. This PR gives the user the choice to hide the icon and text if none.

## Checklist:

- [ ] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [x] I have updated the `theme.toml`, as applicable.

I updated the exampleSite config, and I included a comment describing it. If that is not preferable, I can remove the comment and add the text to the wiki.
