### PR TITLE
Show whole post on short posts

### DIFF
--- a/layouts/_default/content-list.html
+++ b/layouts/_default/content-list.html
@@ -2,17 +2,17 @@
   {{ .Render "header" }}
   <div class="content">
     {{ .Render "featured" }}
-    {{ $.Scratch.Set "summary" ((delimit (findRE "<p.*?>(.|\n)*?</p>" .Content 2) "") | truncate (default 500 .Site.Params.summary_length) (default "&hellip;" .Site.Params.text.truncated ) | replaceRE "&amp;" "&" | safeHTML) }}
-    {{ if and (eq .Site.Params.readMoreHide true) (ge (len .Content) 500) }}
+    {{ $.Scratch.Set "summary" ((delimit (findRE "<p.*?>(.|\n)*?</p>" .Content 2) "") | truncate (.Site.Params.summaryLength) (default "&hellip;" .Site.Params.text.truncated ) | replaceRE "&amp;" "&" | safeHTML) }}
+    {{ if and (.Site.Params.hideReadMore) (ge (len .Content) 500) }}
       {{ $.Scratch.Get "summary" }}
-    {{ else if and (eq .Site.Params.readMoreHide true) (lt (len .Content) 500) }}
+    {{ else if and (.Site.Params.hideReadMore) (lt (len .Content) 500) }}
       {{ .Content }}
     {{ else }}
       {{ $.Scratch.Get "summary" }}
     {{ end }}
   </div>
   <footer>
-    {{ if and (eq .Site.Params.readMoreHide true) (ge (len .Content) 500) }}
+    {{ if and (.Site.Params.hideReadMore) (ge (len .Content) 500) }}
       <a href="{{ .RelPermalink }}" class="button big">{{ i18n "read_more" }}</a>
     {{ end }}
     {{ .Render "stats" }}

--- a/layouts/_default/content-list.html
+++ b/layouts/_default/content-list.html
@@ -2,17 +2,10 @@
   {{ .Render "header" }}
   <div class="content">
     {{ .Render "featured" }}
-    {{ $.Scratch.Set "summary" ((delimit (findRE "<p.*?>(.|\n)*?</p>" .Content 2) "") | truncate (.Site.Params.summaryLength) (default "&hellip;" .Site.Params.text.truncated ) | replaceRE "&amp;" "&" | safeHTML) }}
-    {{ if and (.Site.Params.hideReadMore) (ge (len .Content) 500) }}
-      {{ $.Scratch.Get "summary" }}
-    {{ else if and (.Site.Params.hideReadMore) (lt (len .Content) 500) }}
-      {{ .Content }}
-    {{ else }}
-      {{ $.Scratch.Get "summary" }}
-    {{ end }}
+    {{ .Content | safeHTML | truncate 500 }}
   </div>
   <footer>
-    {{ if and (.Site.Params.hideReadMore) (ge (len .Content) 500) }}
+    {{ if .Truncated }}
       <a href="{{ .RelPermalink }}" class="button big">{{ i18n "read_more" }}</a>
     {{ end }}
     {{ .Render "stats" }}

--- a/layouts/_default/content-list.html
+++ b/layouts/_default/content-list.html
@@ -2,11 +2,19 @@
   {{ .Render "header" }}
   <div class="content">
     {{ .Render "featured" }}
-    {{ $.Scratch.Set "summary" ((delimit (findRE "<p.*?>(.|\n)*?</p>" .Content 1) "") | truncate (default 500 .Site.Params.summary_length) (default "&hellip;" .Site.Params.text.truncated ) | replaceRE "&amp;" "&" | safeHTML) }}
-    {{ $.Scratch.Get "summary" }}
+    {{ $.Scratch.Set "summary" ((delimit (findRE "<p.*?>(.|\n)*?</p>" .Content 2) "") | truncate (default 500 .Site.Params.summary_length) (default "&hellip;" .Site.Params.text.truncated ) | replaceRE "&amp;" "&" | safeHTML) }}
+    {{ if and (eq .Site.Params.readMoreHide true) (ge (len .Content) 500) }}
+      {{ $.Scratch.Get "summary" }}
+    {{ else if and (eq .Site.Params.readMoreHide true) (lt (len .Content) 500) }}
+      {{ .Content }}
+    {{ else }}
+      {{ $.Scratch.Get "summary" }}
+    {{ end }}
   </div>
   <footer>
-    <a href="{{ .RelPermalink }}" class="button big">{{ i18n "read_more" }}</a>
+    {{ if and (eq .Site.Params.readMoreHide true) (ge (len .Content) 500) }}
+      <a href="{{ .RelPermalink }}" class="button big">{{ i18n "read_more" }}</a>
+    {{ end }}
     {{ .Render "stats" }}
   </footer>
 </article>


### PR DESCRIPTION
## Description

Adds logic to content-list html to allow users to show the full post on the content-list if the post has fewer than 500 characters.

## Motivation and Context

Currently, if you have a short post - say a post that's just an image, or one with only a few words - then you still get a "summary" of it in the content list, with a "read more" button. This gives the user the option to show the full post if the post has fewer than 500 characters.

## Checklist:

- [ ] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [x] I have updated the `theme.toml`, as applicable.

I updated the example site config with the new param. And left a comment describing it. If preferable, I can remove the comment and/or add the info to the wiki.

This ([and my other PR](https://github.com/pacollins/hugo-future-imperfect-slim/pull/174)) should not be showing those extra commits... I hate it when github does this. I will look into resolving it. But it shouldn't affect merging.