### PR TITLE
Add theme-level OpenGraph tags

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -7,13 +7,7 @@
   {{ with .Description }}<meta property="og:description" content="{{ . }}">{{ end }}
   <meta property="og:url" content="{{ .RelPermalink | absURL }}">
   <meta property="og:type" content="{{ cond .IsHome "website" "article" }}">
-  {{ with .Params.openGraph }}
-    {{ range . }}
-      <meta property="og:image" content="{{ .src | absURL }}">
-      <meta property="og:image:alt" content="{{ .alt }}">
-    {{ end }}
-  {{ end }}
-  {{ with .Params.images }}
+  {{ with or (.Params.openGraph) (.Params.images) }}
     {{ range . }}
       <meta property="og:image" content="{{ .src | absURL }}">
       <meta property="og:image:alt" content="{{ .alt }}">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,7 +4,8 @@
 
   {{ with .Site.Title }}<meta property="og:site_name" content="{{ . }}">{{ end }}
   {{ with .Title }}<meta property=“og:title” content="{{ . }}">{{ end }}
-  {{ with .Description }}<meta property="og:description" content="{{ . }}">{{ end }}
+  <meta property="og:description" content="{{ .Description | default .Site.Params.meta.description }}">
+  <meta property="description" content="{{ .Description | default .Site.Params.meta.description }}">
   <meta property="og:url" content="{{ .RelPermalink | absURL }}">
   <meta property="og:type" content="{{ cond .IsHome "website" "article" }}">
   {{ with or (.Params.openGraph) (.Params.images) }}
@@ -12,6 +13,8 @@
       <meta property="og:image" content="{{ .src | absURL }}">
       <meta property="og:image:alt" content="{{ .alt }}">
     {{ end }}
+  {{ else }}
+    <meta property="og:image" content="{{ .Site.Params.intro.pic.src | absURL }}">
   {{ end }}
   {{ with .Site.Params.Social.twitter}}<meta property="twitter:site" content="{{ . }}">{{ end }}
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -3,7 +3,7 @@
   {{- hugo.Generator -}}
 
   {{ with .Site.Title }}<meta property="og:site_name" content="{{ . }}">{{ end }}
-  {{ with .Title }}<meta property=“og:title” content="{{ . }}">{{ end }}
+  {{ with .Title }}<meta property="og:title" content="{{ . }}">{{ end }}
   <meta property="og:description" content="{{ .Description | default .Site.Params.meta.description }}">
   <meta property="description" content="{{ .Description | default .Site.Params.meta.description }}">
   <meta property="og:url" content="{{ .RelPermalink | absURL }}">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,10 +1,26 @@
 <head>
   {{ partial "meta" . }}
   {{- hugo.Generator -}}
-  {{- template "_internal/schema.html" . -}}
-  {{- template "_internal/opengraph.html" . -}}
-  {{- template "_internal/twitter_cards.html" . -}}
-  {{- template "_internal/google_news.html" . -}}
+
+  {{ with .Site.Title }}<meta property="og:site_name" content="{{ . }}">{{ end }}
+  {{ with .Title }}<meta property=“og:title” content="{{ . }}">{{ end }}
+  {{ with .Description }}<meta property="og:description" content="{{ . }}">{{ end }}
+  <meta property="og:url" content="{{ .RelPermalink | absURL }}">
+  <meta property="og:type" content="{{ cond .IsHome "website" "article" }}">
+  {{ with .Params.openGraph }}
+    {{ range . }}
+      <meta property="og:image" content="{{ .src | absURL }}">
+      <meta property="og:image:alt" content="{{ .alt }}">
+    {{ end }}
+  {{ end }}
+  {{ with .Params.images }}
+    {{ range . }}
+      <meta property="og:image" content="{{ .src | absURL }}">
+      <meta property="og:image:alt" content="{{ .alt }}">
+    {{ end }}
+  {{ end }}
+  {{ with .Site.Params.Social.twitter}}<meta property="twitter:site" content="{{ . }}">{{ end }}
+
   {{- if .Site.Params.enableCDN -}}
     {{- if .Site.Params.highlightjs -}}<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.3/styles/{{ .Site.Params.highlightjsTheme | default "default" }}.min.css">{{- end -}}
     {{- range .Site.Params.cssFiles -}}


### PR DESCRIPTION
## Description

Add theme-level OpenGraph tags.

## Motivation and Context

Closes #162 

## Screenshots (if appropriate):

## Checklist:

- [ ] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [ ] I have updated the `theme.toml`, as applicable.
