### PR TITLE
add opengraph description tag and image fallback

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,7 +4,13 @@
 
   {{ with .Site.Title }}<meta property="og:site_name" content="{{ . }}">{{ end }}
   {{ with .Title }}<meta property=“og:title” content="{{ . }}">{{ end }}
-  {{ with .Description }}<meta property="og:description" content="{{ . }}">{{ end }}
+  {{ with .Description }}
+    <meta property="og:description" content="{{ . }}">
+    <meta property="description" content="{{ . }}">
+  {{ else }}
+    <meta property="og:description" content="{{ .Site.Params.meta.description }}">
+    <meta property="description" content="{{ .Site.Params.meta.description }}">
+  {{ end }}
   <meta property="og:url" content="{{ .RelPermalink | absURL }}">
   <meta property="og:type" content="{{ cond .IsHome "website" "article" }}">
   {{ with .Params.openGraph }}
@@ -18,6 +24,8 @@
       <meta property="og:image" content="{{ .src | absURL }}">
       <meta property="og:image:alt" content="{{ .alt }}">
     {{ end }}
+  {{ else }}
+    <meta property="og:image" content="{{ .Site.Params.intro.pic.src | absURL }}">
   {{ end }}
   {{ with .Site.Params.Social.twitter}}<meta property="twitter:site" content="{{ . }}">{{ end }}
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,13 +4,8 @@
 
   {{ with .Site.Title }}<meta property="og:site_name" content="{{ . }}">{{ end }}
   {{ with .Title }}<meta property=“og:title” content="{{ . }}">{{ end }}
-  {{ with .Description }}
-    <meta property="og:description" content="{{ . }}">
-    <meta property="description" content="{{ . }}">
-  {{ else }}
-    <meta property="og:description" content="{{ .Site.Params.meta.description }}">
-    <meta property="description" content="{{ .Site.Params.meta.description }}">
-  {{ end }}
+  <meta property="og:description" content="{{ .Description | default .Site.Params.meta.description }}">
+  <meta property="description" content="{{ .Description | default .Site.Params.meta.description }}">
   <meta property="og:url" content="{{ .RelPermalink | absURL }}">
   <meta property="og:type" content="{{ cond .IsHome "website" "article" }}">
   {{ with .Params.openGraph }}


### PR DESCRIPTION
## Description

Added onto the opengraph update by:

- Providing a regular description tag (in addition to the og one)
- Providing a fallback (to config param) for the description tags in case the page does not contain front matter with a description param
- Providing a fallback to the og image tag, to the config param.

## Motivation and Context

- Head was missing the regular (non-og) description tag.
- Head didn't account for home page and other pages without front matter

Note: I was going to account for more edge cases - such as when the page _does_ have front matter, but the front matter doesn't have a description param, in which case I had it using the first 70 characters of the content. But then I decided against that, because we should be encouraging users to follow the front matter archetype, and we can't account for _every_ edge case!
