### PR TITLE
Update site-sidebar.html (fix for translation of categories, issue #184)

### DIFF
--- a/layouts/partials/site-sidebar.html
+++ b/layouts/partials/site-sidebar.html
@@ -23,10 +23,10 @@
 
   {{ if .Site.Params.sidebar.categories }}
     {{ if ne ($.Scratch.Get "showCategories") false }}
-      {{ $categoriesCount := len .Site.Taxonomies.categories }}
+
       <section id="categories">
         <header>
-          <h1><a href="{{ "categories" | relLangURL }}">{{ i18n "categories" $categoriesCount }}</a></h1>
+          <h1><a href="{{ "categories" | relLangURL }}">{{ i18n "categories" (len .Site.Taxonomies.categories) }}</a></h1>
         </header>
         <ul>
           {{ $.Scratch.Set "categories" (cond .Site.Params.sidebar.categoriesByCount .Site.Taxonomies.categories.ByCount .Site.Taxonomies.categories.Alphabetical) }}

--- a/layouts/partials/site-sidebar.html
+++ b/layouts/partials/site-sidebar.html
@@ -23,9 +23,10 @@
 
   {{ if .Site.Params.sidebar.categories }}
     {{ if ne ($.Scratch.Get "showCategories") false }}
+      {{ $categoriesCount := len .Site.Taxonomies.categories }}
       <section id="categories">
         <header>
-          <h1><a href="{{ "categories" | relLangURL }}">{{ i18n "categories" }}</a></h1>
+          <h1><a href="{{ "categories" | relLangURL }}">{{ i18n "categories" $categoriesCount }}</a></h1>
         </header>
         <ul>
           {{ $.Scratch.Set "categories" (cond .Site.Params.sidebar.categoriesByCount .Site.Taxonomies.categories.ByCount .Site.Taxonomies.categories.Alphabetical) }}


### PR DESCRIPTION
## Description

This should fix issue #184 by counting the number of categories so hugo (or more precise go-i18n) can decide to use the singular or the plural translation.

**The fix might not work if someone changes the taxonomy names of the site and drops the default one named `categories`.** (However, that might even break the site without the fix I assume (but I didn't test it).)

## Motivation and Context

Closes #184 

## Checklist:

- [ ] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [ ] I have updated the `theme.toml`, as applicable.