### PR TITLE
Enabled rss in example config

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -14,7 +14,7 @@ disableLanguages        = []
   unsafe                = true
 
 [outputs]
-  home                  = ["html", "json"]
+  home                  = ["html", "json", "rss"]
 
 [params]
   enableCDN             = false


### PR DESCRIPTION
## Description

rss is disabled in the example config. rssIntro and rssFooter is activated. Hence, I'd expect the rss-icon to appear.

## Motivation and Context

The definition of the custom output adds json but kicks rss from hugo's default.

## Checklist:

- [ ] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [x ] I have updated the `theme.toml`, as applicable.

The wiki should be updated, too. But I don't see how I can this in this PR. I can provide another one for the wiki... 
