### PR TITLE
add www subdomain to some of the social links to prevent redirects

### DIFF
--- a/layouts/partials/socnet-icon.html
+++ b/layouts/partials/socnet-icon.html
@@ -10,7 +10,7 @@
 {{ with .Site.Social.dribbble }}<li><a href="//dribbble.com/{{.}}" target="_blank" rel="noopener" title="Dribbble" class="fab fa-dribbble"></a></li>{{ end }}
 {{ with .Site.Social.wordpress }}<li><a href="//{{.}}.wordpress.com" target="_blank" rel="noopener" title="WordPress" class="fab fa-wordpress"></a></li>{{ end }}
 {{ with .Site.Social.medium}}<li><a href="//medium.com/@{{.}}" target="_blank" rel="noopener" title="Medium" class="fab fa-medium"></a></li>{{ end }}
-{{ with .Site.Social.linkedin }}<li><a href="//linkedin.com/in/{{.}}" target="_blank" rel="noopener" title="LinkedIn" class="fab fa-linkedin"></a></li>{{ end }}
+{{ with .Site.Social.linkedin }}<li><a href="//www.linkedin.com/in/{{.}}" target="_blank" rel="noopener" title="LinkedIn" class="fab fa-linkedin"></a></li>{{ end }}
 {{ with .Site.Social.linkedin_company }}<li><a href="//linkedin.com/company/{{.}}" target="_blank" rel="noopener" title="LinkedIn Company" class="fab fa-linkedin"></a></li>{{ end }}
 {{ with .Site.Social.foursquare }}<li><a href="//foursquare.com/{{.}}" target="_blank" rel="noopener" title="Foursquare" class="fab fa-foursquare"></a></li>{{ end  }}
 {{ with .Site.Social.xing }}<li><a href="//xing.com/profile/{{.}}" target="_blank" rel="noopener" title="Xing" class="fab fa-xing"></a></li>{{ end }}
@@ -30,7 +30,7 @@
 {{ with .Site.Social.strava }}<li><a href="//strava.com/athletes/{{.}}" target="_blank" rel="noopener" title="Strava" class="fab fa-strava"></a></li>{{ end }}
 {{ with .Site.Social.skype }}<li><a href="skype:{{.}}?userinfo" target="_blank" rel="noopener" title="Skype" class="fab fa-skype"></a></li>{{ end }}
 {{ with .Site.Social.snapchat }}<li><a href="//snapchat.com/add/{{.}}" target="_blank" rel="noopener" title="snapchat" class="fab fa-snapchat"></a></li>{{ end }}
-{{ with .Site.Social.pinterest }}<li><a href="//pinterest.com/{{.}}" target="_blank" rel="noopener" title="Pinterest" class="fab fa-pinterest-p"></a></li>{{ end }}
+{{ with .Site.Social.pinterest }}<li><a href="//www.pinterest.com/{{.}}" target="_blank" rel="noopener" title="Pinterest" class="fab fa-pinterest-p"></a></li>{{ end }}
 {{ with .Site.Social.telegram }}<li><a href="//telegram.me/{{.}}" target="_blank" rel="noopener" title="telegram" class="fab fa-telegram"></a></li>{{ end }}
 {{ with .Site.Social.vine }}<li><a href="//vine.co/{{.}}" target="_blank" rel="noopener" title="Vine" class="fab fa-vine"></a></li>{{ end }}
 {{ with .Site.Social.googlescholar }}<li><a href="//scholar.google.com/citations?user={{.}}" target="_blank" rel="noopener" title="Google Scholar"><i class="ai ai-google-scholar"></i></a></li>{{ end }}


### PR DESCRIPTION
## Description

Added `www` subdomain for linkedin.com and pinterest.com to avoid unnecessary redirects from http to https of the domain. I saw that additional redirect when I inspected my blog with https://web.dev

## Motivation and Context

Remove unnecessary redirect from http to https domain

## Screenshots (if appropriate):

N/A

## Checklist:

- [ ] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [ ] I have updated the `theme.toml`, as applicable.
