### PR TITLE
Use relURL instead of absURL

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -404,7 +404,7 @@ input[type="button"],
   width: fit-content;
   &:hover {
     border: 1px solid $accent-color;
-    color: $accent-color !important;
+    color: $accent-color;
     &:active {
       background-color: $active-color;
     }
@@ -1336,7 +1336,7 @@ figcaption {
   border: 0;
   transition: color $hover, transform $hover;
   &:hover {
-    color: $accent-color !important;
+    color: $accent-color;
     transform: translateY(-10px);
   }
 }

--- a/layouts/_default/featured.html
+++ b/layouts/_default/featured.html
@@ -4,7 +4,7 @@
   {{- $stretch := .Site.Params.imageStretch -}}
   {{- $blur := .Site.Params.removeBlur -}}
   {{- if .Params.featured -}}
-    {{- $src = (path.Join "img" (cond (eq .Params.featuredpath "date") (.Page.Date.Format "2006/01") (.Params.featuredpath)) .Params.featured) | absURL -}}
+    {{- $src = (path.Join "img" (cond (eq .Params.featuredpath "date") (.Page.Date.Format "2006/01") (.Params.featuredpath)) .Params.featured) | relURL -}}
     {{- $alt = .Params.featuredalt -}}
     {{- with .Params.featuredstretch -}}
       {{- $stretch = . -}}
@@ -14,7 +14,7 @@
     {{- end -}}
   {{- else if .Params.images -}}
     {{- range first 1 .Params.images -}}
-      {{- $src = .src | absURL -}}
+      {{- $src = .src | relURL -}}
       {{- $alt = .alt -}}
       {{- with .stretch -}}
         {{- $stretch = . -}}

--- a/layouts/partials/site-intro.html
+++ b/layouts/partials/site-intro.html
@@ -1,5 +1,5 @@
 <section id="site-intro" {{ if (and (.Site.Params.intro.hideWhenSingleColumn) (not (and .Page.IsHome .Site.Params.intro.alwaysOnHomepage))) }}class="hidden-single-column"{{ end }}>
-  {{ with .Site.Params.intro.pic }}<a href="{{ "/" | relLangURL}}"><img src="{{ .src | absURL }}"{{ with .shape}} class="{{ . }}"{{ end }} width="{{ .width | default "100" }}" alt="{{ .alt }}" /></a>{{ end }}
+  {{ with .Site.Params.intro.pic }}<a href="{{ "/" | relLangURL}}"><img src="{{ .src | relURL }}"{{ with .shape}} class="{{ . }}"{{ end }} width="{{ .width | default "100" }}" alt="{{ .alt }}" /></a>{{ end }}
   <header>
     {{ with .Site.Params.intro.header }}<h1>{{ . | safeHTML }}</h1>{{ end }}
   </header>

--- a/layouts/shortcodes/fancybox.html
+++ b/layouts/shortcodes/fancybox.html
@@ -48,7 +48,7 @@
   {{ $caption  := $.Scratch.Get "caption" }}
   {{ $gallery := $.Scratch.Get "gallery" }}
   <figure>
-    <a data-fancybox="{{ $gallery }}" href="{{ path.Join $path $file | relURL }}" data-caption="{{ $caption }}"><img src="{{ path.Join $path $file | absURL }}"></a>
+    <a data-fancybox="{{ $gallery }}" href="{{ path.Join $path $file | relURL }}" data-caption="{{ $caption }}"><img src="{{ path.Join $path $file | relURL }}"></a>
     <figcaption>{{ $caption }}</figcaption>
   </figure>
 {{ end }}


### PR DESCRIPTION
Hello! We are building our website out of this theme, and want to share our work here after having pretty good success using your theme!

## Description

This change allows for building the site locally and deploying globally without finding bad links and weird "localhost:1234/img/foo"-style names for e.g. (feature) images and others. This is mostly because our "`baseurl`"s in the TOML are simple "/" paths when it comes to non-local builds.

## Motivation and Context

We found this was because when we generated the site locally it used `absURL` instead of `relURL`. By using `relURL`, it more closely enabled our deployment scheme without having to specifically inject a "`baseurl`" TOML entry just for deploying to production.

## Checklist:

We do not believe either updating the Wiki or the `theme.toml` is applicable here, unless you think this change must be documented.

Let us know!

-- Shepherd's Oasis