### PR TITLE
Remove double slash before .Params.emailService

### DIFF
--- a/layouts/_default/contact.html
+++ b/layouts/_default/contact.html
@@ -12,7 +12,7 @@
           {{ if .Params.netlify }}
             <form name="contact" method="POST" action="thank-you" data-netlify-recaptcha="true" data-netlify="true" center width="300px">
           {{ else }}
-            <form id="contact" action="//{{ .Params.emailService }}" method="post" center width="300px">
+            <form id="contact" action="{{ .Params.emailService }}" method="post" center width="300px">
           {{ end }}
           <h4>{{ i18n "contact_replies" .Params.contactanswertime }}</h4>
           <fieldset>


### PR DESCRIPTION
## Description

```diff
diff --git a/layouts/_default/contact.html b/layouts/_default/contact.html
index 4986b06..d1929bc 100644
--- a/layouts/_default/contact.html
+++ b/layouts/_default/contact.html
@@ -12,7 +12,7 @@
           {{ if .Params.netlify }}
             <form name="contact" method="POST" action="thank-you" data-netlify-recaptcha="true" data-netlify="true" center width="300px">
           {{ else }}
-            <form id="contact" action="//{{ .Params.emailService }}" method="post" center width="300px">
+            <form id="contact" action="{{ .Params.emailService }}" method="post" center width="300px">
           {{ end }}
           <h4>{{ i18n "contact_replies" .Params.contactanswertime }}</h4>
           <fieldset>
```

## Motivation and Context

Closes #200 

## Screenshots (if appropriate):

[You can use `Windows+Shift+S` or `Control+Command+Shift+4` to add a screenshot to your clipboard and then paste it here.]

## Checklist:

- [ ] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [ ] I have updated the `theme.toml`, as applicable.
