### PR TITLE
Fix the Japanese translation of "About"

### DIFF
--- a/i18n/ja.toml
+++ b/i18n/ja.toml
@@ -14,7 +14,7 @@
 
 # Sections
 [about]
-  other = "約"
+  other = "本サイトについて"
 [contact]
   other = "お問い合わせ"
 [contact_replies]


### PR DESCRIPTION
## Description

Fix the Japanese translation of "About".

"約" → "本サイトについて"

## Motivation and Context

Closes https://github.com/pacollins/hugo-future-imperfect-slim/issues/203

## Screenshots (if appropriate):

PC
<img src="https://user-images.githubusercontent.com/22971513/98128067-c9216b80-1efa-11eb-840c-8d7b7cdcc7ba.png" width=400>

Mobile
<img src="https://user-images.githubusercontent.com/22971513/98128071-caeb2f00-1efa-11eb-953d-c39996ec2c40.png" width=400>


## Checklist:

- [ ] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [ ] I have updated the `theme.toml`, as applicable.
