### PR TITLE
Add simple TableOfContents

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -1393,6 +1393,15 @@ figcaption {
   }
 }
 
+#TableOfContents {
+  border: 1px dotted #afafaf;
+
+  ul {
+    list-style-type: none;
+    padding-inline-start: 1.5em;
+  }
+}
+
 /* ==========================================================================
    Add-Ons
    ========================================================================== */

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -29,6 +29,8 @@ disableLanguages        = []
   removeBlur            = false
   socialShare           = ["twitter", "facebook", "reddit", "linkedin", "pinterest", "email"]
   hideEmptyStats        = false
+  toc                   = true
+  tocWords              = 400
 
   [params.meta]
     description         = "A theme by HTML5 UP, ported by Julio Pescador. Slimmed and enhanced by Patrick Collins. Multilingual by StatnMap. Powered by Hugo."

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,6 +6,9 @@
     </div>
     <div class="content">
       {{ .Render "featured" }}
+      {{ if and (gt .WordCount .Site.Params.tocWords) ( .Site.Params.toc ) }}
+        {{ .TableOfContents }}
+      {{ end }}
       {{ .Content }}
     </div>
     <footer>


### PR DESCRIPTION
## Description

I need TableOfContents in a blog post page.

## Motivation and Context

Adds table of contents to a blog post page.

#132

## Screenshots (if appropriate):

<img width="858" alt="image" src="https://user-images.githubusercontent.com/566026/103502023-d1b3f680-4e04-11eb-8bee-eb05cab3ad9f.png">

## Checklist:

- [ ] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [ ] I have updated the `theme.toml`, as applicable.
