### PR TITLE
Disable notification for prod and keep it for dev only

### DIFF
--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -1,7 +1,9 @@
 <!--[if IE]>
   <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="https://browsehappy.com/">upgrade your browser</a> to improve your experience and security.</p>
 <![endif]-->
-{{ partial "theme-notification" . }}
+{{ if eq hugo.Environment "development" }}
+  {{ partial "theme-notification" . }}
+{{ end }}
 <header id="site-header">
   <nav id="site-nav">
     <h1 class="nav-title">


### PR DESCRIPTION
## Description

When I deployed website and loaded it from Firefox - I found that the theme-notification message is blinking on every load.
Then I checked code and found that message renders for production as well as for development environment.
Hugo has `hugo.Environment` variable which can be changed by --environment parameter and by default in `hugo serve` it sets to `development` and in `hugo` by `production` values.
So, let's use the variable to show the message only on DEV environment?

## Motivation and Context

Remove theme-notification from production deployment at all, not only by JS.

## Screenshots (if appropriate):

Doesn't need

## Checklist:

- [x] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [x] I have updated the `theme.toml`, as applicable.
