### PR TITLE
Add Utteranc.es integration

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -70,6 +70,14 @@ disableLanguages        = []
     rssFooter           = true
     socialFooter        = true
 
+  [params.utterances]
+    enabled             = false
+    repo                = ""
+    issueTerm           = "pathname"
+    issueNumber         = ""
+    label               = "" 
+    theme               = "github-light"
+
   [params.staticman]
     enabled             = true
     api                 = ""  # No Trailing Slash

--- a/layouts/_default/comments.html
+++ b/layouts/_default/comments.html
@@ -3,6 +3,17 @@
     {{ template "_internal/disqus.html" . }}
   </article>
 
+{{ else if .Site.Params.utterances.enabled }}
+  <script src="https://utteranc.es/client.js"
+          repo="{{ .Site.Params.utterances.repo }}"
+          issue-term="{{ .Site.Params.utterances.issueTerm }}"
+          issue-number="{{ .Site.Params.utterances.issueNumber }}"
+          label="{{ .Site.Params.utterances.label }}"
+          theme="{{ .Site.Params.utterances.theme }}"
+          crossorigin="anonymous"
+          async>
+  </script>
+
 {{/* Backwards compatibility for deprecated parameter ".Site.Params.staticman.staticman" */}}
 {{ else if or .Site.Params.staticman.enabled .Site.Params.staticman.staticman }}
   <article class="post">

--- a/theme.toml
+++ b/theme.toml
@@ -7,11 +7,11 @@ tags = ["Academic", "Academicons", "Blog", "Contact Form", "CSS Grid", "Disqus",
         "Fancybox", "Font Awesome", "Gallery", "Google Analytics", "Google News",
         "Highlight.js", "Jquery", "Lunr.js", "Multilingual", "Netlify",
         "Responsive", "Search",  "Open Graph", "Staticman", "Syntax Highlighting",
-        "Twitter Cards"]
+        "Twitter Cards", "Utteranc.es"]
 features = ["Academicons v1.8.6", "Disqus", "Fancybox v3.5.7", "Font Awesome v5.13.0",
             "Google Analytics", "Google News", "Highlight.js v10.0.3", "Jquery v3.5.1",
             "Lunr.js v2.3.8", "Netlify", "Open Graph", "Staticman", "Theme Update Notification",
-            "Twitter Cards"]
+            "Twitter Cards", "Utteranc.es"]
 min_version = "v0.62.0/extended"
 
 [author]


### PR DESCRIPTION
## Description

Added an integration with [Utteranc.es](https://github.com/utterance/utterances). Updated config.toml and comments.html

## Motivation and Context

[Why is this change required? What problem does it solve?]
I was doing this for myself, so I figured I'd give back in case anyone else wanted this option.

[If it fixes an open issue, please link to the issue here by writing "Closes #XXX"]

## Screenshots (if appropriate):

[You can use `Windows+Shift+S` or `Control+Command+Shift+4` to add a screenshot to your clipboard and then paste it here.]

## Checklist:

I updated the documentation on the wiki on my side.

- [x] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [x] I have updated the `theme.toml`, as applicable.
