### PR TITLE
Remove references to my Staticman bot

### DIFF
--- a/assets/js/staticman.js
+++ b/assets/js/staticman.js
@@ -9,7 +9,7 @@ $(document).ready(function() {
     $('input[type="submit"]:disabled').removeClass('hidden'); // show "submitted"
 
     // Construct form action URL form JS to avoid spam
-    var api = '{{ .api | default "staticman3.herokuapp.com" }}';
+    var api = '{{ .api }}';
     var gitProvider = '{{ .gitprovider }}';
     var username = '{{ .username }}';
     var repo = '{{ .repo }}';


### PR DESCRIPTION
## Motivation and Context

A commit that I should make a year ago.  Sorry for delay.  I've made it now due
to

1. Staticman's maintainer's recommendation to move away from any public API
instance in issue 317.
2. My recent successful setup of my new personal API instance on Heroku, thanks
to
    - a one-click deploy button to Heroku
    - an online article about GitHub App setup for Staticman v3

    Successful MWE: see https://git.io/smdemo

As a result, I wrote a little guide with some screenshots that would illustrate well the steps in the repo's wiki page, hoping to make the setup of a personal API instance easy.

## Description

Remove the default fallback to my former Staticman API instance.

## Checklist:

- [x] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [ ] I have updated the `theme.toml`, as applicable.
