### PR TITLE
fixed HTML syntax error in closing tags

### DIFF
--- a/exampleSite/content/blog/emoji-support.fr.md
+++ b/exampleSite/content/blog/emoji-support.fr.md
@@ -17,7 +17,7 @@ La fonction [`emojify`] (https://gohugo.io/functions/emojify/) peut être appel�
 Pour activer globalement emoji, définissez `enableEmoji` sur` true` dans la [configuration] de votre site (https://gohugo.io/getting-started/configuration/), puis vous pourrez taper des codes abrégés emoji directement dans les fichiers de contenu; par exemple.
 
 
-<p> <span class = "nowrap"> <span class = "emojify"> 🙈 </ span> <code>: see_no_evil: </ code> </ span> <span class = "nowrap"> <span class = "emojify"> 🙉 </ span> <code>: hear_no_evil: </ code> </ span> <span class = "nowrap"> <span class = "emojify"> </ span> <code>: speak_no_evil: </ code> </ span> </ p>
+<p> <span class = "nowrap"> <span class = "emojify"> 🙈 </span> <code>: see_no_evil: </code> </span> <span class = "nowrap"> <span class = "emojify"> 🙉 </span> <code>: hear_no_evil: </code> </span> <span class = "nowrap"> <span class = "emojify"> </span> <code>: speak_no_evil: </code> </span> </p>
 <br>
 
 Le [aide-mémoire Emoji] (http://www.emoji-cheat-sheet.com/) est une référence utile pour les codes abrégés emoji.


### PR DESCRIPTION
## Description

Fixed the HTML syntax error for the French Emoji demo page.

## Motivation and Context

Resolve #227 

[If it fixes an open issue, please link to the issue here by writing "Closes #XXX"]

## Screenshots (if appropriate):

![fixed output](https://user-images.githubusercontent.com/5748535/110214435-c0d73e00-7ea4-11eb-975e-e7855e59409b.png)

## Checklist:

- [ ] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [ ] I have updated the `theme.toml`, as applicable.
