### PR TITLE
Use Hugo's relLangURL instead of hard code

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -59,11 +59,7 @@ window.onload = function () {
   $searchResults = document.getElementById('search-results');
   $searchInput   = document.getElementById('search-input');
 
-  var lang = document.documentElement.lang;
-  var path = "/index.json";;
-  if (lang != "{{ .Site.Language }}") {  
-    path = "/"+lang+"/"+"index.json";
-  }
+  var path = "{{ relLangURL "index.json" }}"
   request.open("GET", path, true); // Request the JSON file created during build
   request.onload = function() {
     if (request.status >= 200 && request.status < 400) {


### PR DESCRIPTION
## Description

1. When browsing in the site's default language, the language prefix is omitted: `/index.json`.
2. Otherwise, a language prefix is added: `/{LANG}/index.json`.

## Motivation and Context

Resolve #226 

## Screenshots (if appropriate):

Refer to the linked issue.

## Related

#188 

https://gohugo.io/functions/rellangurl/

## Checklist:

- [ ] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [ ] I have updated the `theme.toml`, as applicable.