### PR TITLE
Replace "/" in "/index.json" with baseURL for project pages

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -60,10 +60,11 @@ window.onload = function () {
   $searchInput   = document.getElementById('search-input');
 
   var lang = document.documentElement.lang;
-  var path = "/index.json";;
-  if (lang != "{{ .Site.Language }}") {  
-    path = "/"+lang+"/"+"index.json";
+  var pathArgs = ["{{ .Site.BaseURL }}", "index.json"];
+  if (lang != "{{ .Site.Language }}") {
+    pathArgs.splice(1, 0, lang);
   }
+  path = pathArgs.join("/");
   request.open("GET", path, true); // Request the JSON file created during build
   request.onload = function() {
     if (request.status >= 200 && request.status < 400) {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -60,7 +60,7 @@ window.onload = function () {
   $searchInput   = document.getElementById('search-input');
 
   var lang = document.documentElement.lang;
-  var pathArgs = ["{{ .Site.BaseURL }}", "index.json"];
+  var pathArgs = ["{{ replaceRE "/$" "" .Site.BaseURL }}", "index.json"];
   if (lang != "{{ .Site.Language }}") {
     pathArgs.splice(1, 0, lang);
   }


### PR DESCRIPTION
## Description

Use [`.Site.BaseURL`](https://gohugo.io/variables/site/#site-variables-list) without trailing `/` instead of leading `/`.

## Motivation and Context

To resolve #226

:information_source: The `/` is resolved to the root of the domain.  In [this relative path problem on SO](https://stackoverflow.com/q/5092352/3184351), the question asker wants `http://localhost/myapp/Shared/AskReason.ashx?...`, but using `var url = "/Shared/AskReason.ashx?...` gives problem.

https://github.com/pacollins/hugo-future-imperfect-slim/blob/fa6c8c0da163dd3ea19822b017464957053f5226/assets/js/main.js#L62-L71

## Screenshots (if appropriate):
### Success on GitHub Pages

GET https://vincenttam.github.io/hugo-future-imperfect-slim/pl/index.json

![Screenshot from 2021-03-09 00-55-13](https://user-images.githubusercontent.com/5748535/110397422-1e6cb580-8072-11eb-9f4f-24e05a4d1cda.png)

### ~Failed~ Succeeded on Frama Pages

![Screenshot from 2021-03-09 00-50-24](https://user-images.githubusercontent.com/5748535/110397070-72c36580-8071-11eb-8f34-c800a629e4b9.png)

I tried hosting this on my testing [Frama Pages](https://docs.framasoft.org/fr/gitlab/gitlab-pages.html):
https://vincenttam.frama.io/fish-demo/
but I ran into a 404 error for the GET request `https://vincenttam.frama.io/fish-demo/index.json` *b/c I omitted the instructions for #143*.

After I made the described changes at [commit d298d0b](https://framagit.org/VincentTam/fish-demo/-/commit/d298d0b), the JSON files were correctly downloaded.

![Screenshot from 2021-03-09 14-24-14](https://user-images.githubusercontent.com/5748535/110479455-b35cc680-80e5-11eb-973e-ebe932033484.png)

Source: https://framagit.org/VincentTam/fish-demo/

However, the error about the favicon is still there on Frama Pages.  That doesn't happen on GitHub Pages—but that's another issue.

> Mixed Content: The page at 'https://vincenttam.frama.io/fish-demo/' was loaded over HTTPS, but requested an insecure favicon 'http:<span>//projects.fram</span>a.io/auth?domain=htt<span>ps://vincenttam.</span>frama.io&state=q1KwJ3bQ4N3kIOX8RH0KhQ=='. This request has been blocked; the content must be served over HTTPS.

## Checklist:

- [ ] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [ ] I have updated the `theme.toml`, as applicable.