### PR TITLE
Fixed some mistakes in site top menu

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -149,7 +149,7 @@ disableLanguages        = []
       weight            = 1
 
     [[Languages.fr.menu.main]]
-      name              = "About"
+      name              = "A Propos"
       identifier        = "about"
       url               = "/about/"
       pre               = "<i class='far fa-id-card'></i>"
@@ -272,12 +272,12 @@ disableLanguages        = []
 
   [Languages.zh-CN]
     LanguageCode        = "zh-CN"
-    LanguageName        = "中文"
+    LanguageName        = "中文 (简体)"
     weight              = 7
 
   [Languages.zh-TW]
     LanguageCode        = "zh-TW"
-    LanguageName        = "中文"
+    LanguageName        = "中文 (正體)"
     weight              = 8
 
   [Languages.ja]


### PR DESCRIPTION
## Description

1. added back French UI string for "Home".  The code blocks below shows that that was missing in the past.

    https://github.com/pacollins/hugo-future-imperfect-slim/blob/35c1b58bbfa91b9625dacf53af3542bf306b458e/i18n/fr.toml#L16-L17

    https://github.com/pacollins/hugo-future-imperfect-slim/blob/35c1b58bbfa91b9625dacf53af3542bf306b458e/exampleSite/config.toml#L151-L154

2. added back a proper localized language name for both Chinese (Simplified) and Chinese (Traditional) so that it makes sense.

    https://github.com/pacollins/hugo-future-imperfect-slim/blob/35c1b58bbfa91b9625dacf53af3542bf306b458e/exampleSite/config.toml#L273-L281

## Motivation and Context

To make the displayed text in the top menu bar and the language bar more sensible.

## Screenshots (if appropriate):

![Screenshot from 2021-03-09 15-16-57](https://user-images.githubusercontent.com/5748535/110484015-92e33b00-80ea-11eb-981c-0aee55718c70.png)

[The French version of my fork's `exampleSite`](https://vincenttam.github.io/hugo-future-imperfect-slim/fr/) displays the Chinese lanuage names and the French translation of "About" ("A Propos") properly after I [merged](https://github.com/VincentTam/hugo-future-imperfect-slim/commit/96edd74) the branch for this PR to my source branch  `addGHCI` for hosting `exampleSite` with GitHub Actions.

## Checklist:

- [ ] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [ ] I have updated the `theme.toml`, as applicable.
