### PR TITLE
Vanilla Staticman JS & HTML reorganization

### DIFF
--- a/assets/js/staticman.js
+++ b/assets/js/staticman.js
@@ -16,7 +16,7 @@
 
       // Convert form fields to a JSON-friendly string
       let formObj = Object.fromEntries(new FormData(form));
-      let xhrObj = {fields: {}, options:{}};
+      let xhrObj = {fields: {}, options: {}};
       Object.entries(formObj).forEach(([key, value]) => {
         let a = key.indexOf('['), b = key.indexOf('reCaptcha');
         if (a == -1) { // key = "g-recaptcha-response"
@@ -24,7 +24,8 @@
         } else if (a == 6 || (a == 7 && b == -1)) { // key = "fields[*]", "options[*]"
           xhrObj[key.slice(0, a)][key.slice(a + 1, -1)] = value;
         } else { // key = "options[reCaptcha][*]"
-          xhrObj.options.reCaptcha = {};
+          // define xhrObj.options.reCaptcha if it doesn't exist
+          xhrObj.options.reCaptcha = xhrObj.options.reCaptcha || {};
           xhrObj.options.reCaptcha[key.slice(b + 11, -1)] = value;
         }
       });
@@ -33,7 +34,7 @@
 
       let xhr = new XMLHttpRequest();
       xhr.open('POST', url);
-      xhr.setRequestHeader('Content-Type', 'application/json; charset=UTF-8');
+      xhr.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');
       xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
       xhr.onreadystatechange = function () {
         if (xhr.readyState === XMLHttpRequest.DONE) {

--- a/assets/js/staticman.js
+++ b/assets/js/staticman.js
@@ -1,108 +1,105 @@
-// Static comments
-// from: https://github.com/eduardoboucas/popcorn/blob/gh-pages/js/main.js
-$(document).ready(function() {
-  $('.new-comment').submit(function () {
-    var form = this;
+(function() {
+  var form = document.querySelector('.new-comment');
+  if (form) {
+    form.addEventListener('submit', function () {
+      form.classList.add('loading');
+      form.querySelector('input[type="submit"]:enabled').classList.add('hidden'); // hide "submit"
+      form.querySelector('input[type="submit"]:disabled').classList.remove('hidden'); // show "submitted"
 
-    $(form).addClass('loading');
-    $('input[type="submit"]:enabled').addClass('hidden'); // hide "submit"
-    $('input[type="submit"]:disabled').removeClass('hidden'); // show "submitted"
+      // Construct form action URL form JS to avoid spam
+      let api = '{{ .api }}';
+      let gitProvider = '{{ .gitprovider }}';
+      let username = '{{ .username }}';
+      let repo = '{{ .repo }}';
+      let branch = '{{ .branch }}';
+      let url = ['https:/', api, 'v3/entry', gitProvider, username, repo, branch, 'comments'].join('/');
+      let formData = JSON.stringify(Object.fromEntries(new FormData(form)));  // some API don't accept FormData objects
 
-    // Construct form action URL form JS to avoid spam
-    var api = '{{ .api }}';
-    var gitProvider = '{{ .gitprovider }}';
-    var username = '{{ .username }}';
-    var repo = '{{ .repo }}';
-    var branch = '{{ .branch }}';
+      var xhr = new XMLHttpRequest();
+      xhr.open('POST', url);
+      xhr.setRequestHeader('Content-Type', 'application/json; charset=UTF-8');
+      xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+      xhr.onreadystatechange = function () {
+        if(xhr.readyState === XMLHttpRequest.DONE) {
+          var status = xhr.status;
+          if (status >= 200 && status < 400) {
+            formSubmitted();
+          } else {
+            formError(err);
+          }
+        }
+      };
+      xhr.send(formData);
 
-    $.ajax({
-      type: $(this).attr('method'),
-      url: ['https:/', api, 'v3/entry', gitProvider, username, repo, branch, 'comments'].join('/'),
-      data: $(this).serialize(),
-      contentType: 'application/x-www-form-urlencoded',
-      success: function (data) {
-        showAlert('success');
-        setTimeout(function(){ clearForm() }, 3000); // display success message for 3s
-        $(form).removeClass('loading');
-      },
-      error: function (err) {
-        console.log(err);
-        showAlert('failed');
-        $(form).removeClass('loading');
+      return false;
+    });
+
+    function formSubmitted() {
+      showAlert('success');
+      setTimeout(function(){ clearForm() }, 3000); // display success message for 3s
+      form.classList.remove('loading');
+    }
+
+    function formError(err) {
+      console.log(err);
+      showAlert('failed');
+      form.classList.remove('loading');
+    }
+
+    function showAlert(msg) {
+      if (msg == 'success') {
+        form.querySelector('.submit-notice').classList.add('submit-success')
+        form.querySelector('.submit-success').classList.remove('hidden');  // show submit success message
+        form.querySelector('.submit-failed').classList.add('hidden'); // hide submit failed message
+      } else {
+        form.querySelector('.submit-notice').classList.add('submit-failed')
+        form.querySelector('.submit-success').classList.add('hidden'); // hide submit success message
+        form.querySelector('.submit-failed').classList.remove('hidden');  // show submit failed message
+      }
+      form.querySelector('input[type="submit"]:enabled').classList.remove('hidden'); // show "submit"
+      form.querySelector('input[type="submit"]:disabled').classList.add('hidden');  // hide "submitted"
+    }
+
+    // empty all text & hidden fields but not options
+    function clearForm() {
+      resetReplyTarget();
+      form.querySelector('.submit-notice').classList.remove('.submit-success'); // IE10 compatibility
+      form.querySelector('.submit-notice').classList.remove('.submit-failed');
+      form.querySelector('.submit-success').classList.add('hidden'); // hide submission status
+      form.querySelector('.submit-failed').classList.add('hidden'); // hide submission status
+    }
+
+    function resetReplyTarget() {
+      form.querySelector('.reply-notice .reply-name').innerText = '';
+      form.querySelector('.reply-notice').classList.add('hidden'); // hide reply target display
+      // empty all hidden fields whose name starts from "reply"
+      Array.from(form.elements).filter(e => e.name.indexOf('fields[reply') === 0).forEach(e => e.value = '');
+    }
+
+    // record reply target when one of the "reply" buttons is pressed
+    document.querySelector('.comments-container').addEventListener('click', function (evt) {
+      let target = evt.target;
+      if (target.matches('.comment-reply-btn')){
+        resetReplyTarget();
+        let cmt = target;
+        while (!cmt.matches('.comment')) {  // find the comment containing the clicked "reply" button
+          cmt = cmt.parentNode;
+        }
+        form.querySelector('input[name="fields[replyThread]"]').value = cmt.dataset.replyThread;
+        form.querySelector('input[name="fields[replyID]"]').value = cmt.getAttribute('id');
+        let replyName = cmt.querySelector('.comment-author').innerText
+        form.querySelector('input[name="fields[replyName]"]').value = replyName;
+
+        // display reply name
+        form.querySelector('.reply-notice').classList.remove('hidden');
+        form.querySelector('.reply-name').innerText = replyName;
       }
     });
 
-    return false;
-  });
+    // handle removal of reply target when '×' is pressed
+    form.querySelector('.reply-close-btn').addEventListener('click', resetReplyTarget);
 
-  function showAlert(msg) {
-    if (msg == 'success') {
-      $('.submit-notice').addClass('submit-success')
-      $('.new-comment .submit-success').removeClass('hidden');  // show submit success message
-      $('.new-comment .submit-failed').addClass('hidden'); // hide submit failed message
-    } else {
-      $('.submit-notice').addClass('submit-failed')
-      $('.new-comment .submit-success').addClass('hidden'); // hide submit success message
-      $('.new-comment .submit-failed').removeClass('hidden');  // show submit failed message
-    }
-    $('input[type="submit"]:enabled').removeClass('hidden'); // show "submit"
-    $('input[type="submit"]:disabled').addClass('hidden');  // hide "submitted"
+    // clear form when reset button is clicked
+    form.querySelector('input[type="reset"]').addEventListener('click', clearForm);
   }
-
-  function clearForm() {
-    resetReplyTarget();
-    $('.new-comment input')
-      .filter(function() {
-        return this.name.match(/^fields\[.*\]$/);
-      })
-      .val(''); // empty all text & hidden fields but not options
-    $('.new-comment textarea').val(''); // empty text area
-    $('.submit-notice').removeClass('.submit-success').removeClass('.submit-failed');
-    $('.new-comment .submit-success').addClass('hidden'); // hide submission status
-    $('.new-comment .submit-failed').addClass('hidden'); // hide submission status
-  }
-
-  function resetReplyTarget() {
-    $('.new-comment .reply-notice .reply-name').text('');
-    $('.new-comment .reply-notice .comment-avatar').remove();
-    $('.new-comment .reply-notice .reply-close-btn').remove();
-    $('.new-comment .reply-notice').addClass('hidden'); // hide reply target display
-    $('.new-comment input[type="hidden"]')
-      .filter(function() {
-        return this.name.match(/^fields\[reply[a-zA-Z]*\]$/);
-      })
-      .val(''); // empty all hidden fields whose name starts from "reply"
-  }
-
-  // record reply target when "reply to this comment" is pressed
-  $('.comment').on('click', '.comment-reply-btn', function (evt){
-    resetReplyTarget();
-    var cmt = $(evt.delegateTarget);
-    var replyThread = cmt.find('.comment-threadID').text();
-    $('.new-comment input[name="fields[replyThread]"]').val(replyThread);
-    $('.new-comment input[name="fields[replyID]"]').val(cmt.attr("id"));
-    authorTag = cmt.find('.comment-author');
-    replyName = authorTag.text();
-    $('.new-comment input[name="fields[replyName]"]').val(replyName);
-
-    // display reply target avatar and name
-    $('.new-comment .reply-notice').removeClass('hidden');
-    $('.new-comment .reply-name').text(replyName);
-    avatarTag = cmt.find('.comment-avatar');
-    // use clone to avoid removal of avatar in comments by resetReplyTarget()
-    $('.new-comment .reply-arrow').after(avatarTag.clone());
-    // add button for removing reply target (static method would give error msg)
-    closeBtn = $("<a class='reply-close-btn button'><i class='fas fa-times'></i></a>");
-    $('.new-comment .reply-notice').append(closeBtn);
-  });
-
-  // handle removal of reply target when '×' is pressed
-  $('.new-comment .reply-notice').on('click', '.reply-close-btn', function(){
-    resetReplyTarget();
-  });
-
-  // clear form when reset button is clicked
-  $('.new-comment input[type="reset"]').click(function (){
-    clearForm();
-  });
-});
+})();

--- a/layouts/_default/comments.html
+++ b/layouts/_default/comments.html
@@ -1,35 +1,36 @@
 {{ if .Site.DisqusShortname }}
-  <article class="post">
+  <div class='post'>
     {{ template "_internal/disqus.html" . }}
-  </article>
+  </div>
 
 {{ else if .Site.Params.utterances.enabled }}
-  <script src="https://utteranc.es/client.js"
-          repo="{{ .Site.Params.utterances.repo }}"
-          issue-term="{{ .Site.Params.utterances.issueTerm }}"
-          issue-number="{{ .Site.Params.utterances.issueNumber }}"
-          label="{{ .Site.Params.utterances.label }}"
-          theme="{{ .Site.Params.utterances.theme }}"
-          crossorigin="anonymous"
+  <script src='https://utteranc.es/client.js'
+          repo='{{ .Site.Params.utterances.repo }}'
+          issue-term='{{ .Site.Params.utterances.issueTerm }}'
+          issue-number='{{ .Site.Params.utterances.issueNumber }}'
+          label='{{ .Site.Params.utterances.label }}'
+          theme='{{ .Site.Params.utterances.theme }}'
+          crossorigin='anonymous'
           async>
   </script>
 
 {{/* Backwards compatibility for deprecated parameter ".Site.Params.staticman.staticman" */}}
 {{ else if or .Site.Params.staticman.enabled .Site.Params.staticman.staticman }}
-  <article class="post">
+  <div class='post'>
     {{/* $entryId stores the transformed current path for sorting Staticman data file */}}
     {{- $entryId := .File.UniqueID -}}
     {{/* Additional div wrapper for proper consistent margin */}}
     <div>
-      <h2 id="say-something">{{ i18n "say_something" }}</h2>
-        <form id="comment-form" class="new-comment" method="POST">
+      <h2 id='say-something'>{{ i18n "say_something" }}</h2>
+        <form id='comment-form' class='new-comment' method='POST'>
           {{/* Display reply target */}}
           <h3 class='reply-notice hidden'>
             <span class='reply-name'></span>
+            <a class='reply-close-btn button'><i class='fas fa-times'></i></a>
           </h3>
 
           {{/* Hidden fields */}}
-          <input type="hidden" name="options[entryId]" value="{{ $entryId }}">
+          <input type='hidden' name='options[entryId]' value='{{ $entryId }}'>
           <input type='hidden' name='fields[replyThread]' value=''>
           <input type='hidden' name='fields[replyID]' value=''>
           <input type='hidden' name='fields[replyName]' value=''>
@@ -43,9 +44,9 @@
           {{/* reCAPTHCA v2 */}}
           {{ if and .Site.Params.staticman.recaptcha.siteKey .Site.Params.staticman.recaptcha.encryptedKey }}
           {{ with .Site.Params.staticman.recaptcha }}
-            <input hidden name="options[reCaptcha][siteKey]" value="{{ .sitekey }}">
-            <input hidden name="options[reCaptcha][secret]" value="{{ .encryptedkey }}">
-            <div class="g-recaptcha" data-sitekey="{{ .sitekey }}"></div>
+            <input hidden name='options[reCaptcha][siteKey]' value='{{ .sitekey }}'>
+            <input hidden name='options[reCaptcha][secret]' value='{{ .encryptedkey }}'>
+            <div class='g-recaptcha' data-sitekey='{{ .sitekey }}'></div>
           {{ end }}
           {{ end }}
 
@@ -63,7 +64,7 @@
     </div>
 
     {{/* Additional div wrapper for proper consistent margin */}}
-    <div>
+    <div class='comments-container'>
       <h2>{{ i18n "comments" }}</h2>
 
       {{- if .Site.Data.comments -}}
@@ -77,31 +78,31 @@
               {{- $threadID := ._id }}
               {{- range $comments -}}
                 {{ if or (in ._id $threadID) (in .replyThread $threadID) }}
-                  <div id="{{ ._id }}" class="comment{{ with .replyThread }} comment-reply{{ end }}">
+                  <article id='{{ ._id }}' class='comment{{ with .replyThread }} comment-reply{{ end }}' data-reply-thread='{{ .replyThread }}'>
                     <header>
-                      <img class="comment-avatar circle" src="https://www.gravatar.com/avatar/{{ .email }}?s=100" alt="{{ .name }}'s Gravatar">
+                      <img class='comment-avatar circle' src='https://www.gravatar.com/avatar/{{ .email }}?s=100' alt="{{ .name }}'s Gravatar">
                       <div>
-                        <div class="comment-author-container">
-                          <h3 class="comment-author">
+                        <div class='comment-author-container'>
+                          <h3 class='comment-author'>
                             {{- if .website -}}
-                              <a rel="external nofollow" href="{{ .website }}">{{ .name }}</a>
+                              <a rel='external nofollow' href='{{ .website }}'>{{ .name }}</a>
                             {{- else -}}
                               {{- .name -}}
                             {{- end -}}
                           </h3>
-                          <a class="comment-date" href="#{{ ._id }}" title="Permalink to this comment">
-                            <time datetime="{{ .date }}">{{ dateFormat "02 Jan 06 15:04" .date }}</time>
+                          <a class='comment-date' href='#{{ ._id }}' title='Permalink to this comment'>
+                            <time datetime='{{ .date }}'>{{ dateFormat "02 Jan 06 15:04" .date }}</time>
                           </a>
                         </div>
                         <!-- TODO: Assess Value (ref ln#73): <a href='#{{ .replyID }}' class='reply-target'>{{ .replyName }}</a> -->
                         <!-- TODO: Assess Value: <span class ="comment-threadID hidden">{{ .replyThread }}</span> -->
-                        <a class="comment-reply-btn" href="#say-something">{{ i18n "reply" }}</a>
+                        <a class='comment-reply-btn' href='#say-something'>{{ i18n "reply" }}</a>
                       </div>
                     </header>
-                    <div class="comment-content">
+                    <div class='comment-content'>
                       {{ .body | markdownify }}
                     </div>
-                  </div>
+                  </article>
                 {{ end }}
               {{ end }}
             {{ end }}
@@ -109,5 +110,5 @@
         {{ end }}
       {{ end }}
     </div>
-  </article>
+  </div>
 {{ end }}

--- a/layouts/_default/comments.html
+++ b/layouts/_default/comments.html
@@ -78,7 +78,7 @@
               {{- $threadID := ._id }}
               {{- range $comments -}}
                 {{ if or (in ._id $threadID) (in .replyThread $threadID) }}
-                  <article id='{{ ._id }}' class='comment{{ with .replyThread }} comment-reply{{ end }}' data-reply-thread='{{ .replyThread }}'>
+                  <article id='{{ ._id }}' class='comment{{ with .replyThread }} comment-reply{{ end }}' data-reply-thread='{{ $threadID }}'>
                     <header>
                       <img class='comment-avatar circle' src='https://www.gravatar.com/avatar/{{ .email }}?s=100' alt="{{ .name }}'s Gravatar">
                       <div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,20 +1,22 @@
 {{ define "main" }}
-  <article class="post">
-    {{ .Render "header" }}
-    <div id="socnet-share">
-      {{ partial "share-buttons" . }}
+  <article>
+    <div class="post">
+      {{ .Render "header" }}
+      <div id="socnet-share">
+        {{ partial "share-buttons" . }}
+      </div>
+      <div class="content">
+        {{ .Render "featured" }}
+        {{ .Content }}
+      </div>
+      <footer>
+        {{ .Render "stats" }}
+      </footer>
     </div>
-    <div class="content">
-      {{ .Render "featured" }}
-      {{ .Content }}
-    </div>
-    <footer>
-      {{ .Render "stats" }}
-    </footer>
+    {{ if not ( eq .Params.comments false) }}
+      {{ .Render "comments" }}
+    {{ end }}
   </article>
-  {{ if not ( eq .Params.comments false) }}
-    {{ .Render "comments" }}
-  {{ end }}
   <div class="pagination">
     {{ if .NextInSection }}
       <a href="{{ .NextInSection.RelPermalink }}" class="button left"><span>{{ .NextInSection.Title }}</span></a>


### PR DESCRIPTION
## Description

1. HTML reorganization:

    ```html
    <article>
    <div class="post">
    </div>
    <div class="comments-container">
        <article class="comment" data-reply-thread="{{ $threadID }}">
        </article>
        <article class="comment">
            <article class="comment comment-reply" data-reply-thread="{{ $threadID }}">
            </article>
        </article>
    </div>
    </article>
    ```

    In my original PR for Staticman's nested comment support #69, I attempted to stored the post's `$threadID` with a hidden `<span>`—that's not the HTML5 way.  I wish I knew the use of `data-` attributes earilier.

    https://github.com/pacollins/hugo-future-imperfect-slim/blob/118943abc5e94ff633a930bf0deaf628fb834459/layouts/post/staticman.html#L72-L83

    Each comment is wrapped by an `<article>` tag with class name `comment` and `id` received from the data file.  Each comment reply is nested inside a main comment.  I've added the class `comments-container` to the `<div>` for JS event delegation (for details, see next point).  I don't touch the commented `TODO` introduced in #154 as I don't know much about the look yet—with the fixed JavaScript, the retrieval of reply target info should be OK.

    I changed the tag name surrounding the Hugo code for Disqus from `<article>` to `<div>`.

    I observed that the styles are controlled by the `post` class in the CSS, so changing the tag name to `article` should be no impact on the styles.

     The quotes for HTML syntax in `layout/_defaults/comments.html` are unified to single quotes.  I left the double quotes in the Hugo code untouched.

2. `assets/js/staticman.js` in Vanilla JS

    - jQuery syntax for HTML element selection `$.(...)` replaced by `document.querySelector(...)` in most cases.
    - jQuery method `ready()` replaced by self-executing JS function `(function(){...})();`
    - some other method translation in the same sense: `val()`, `addClass()`, etc.
    - event delegation: Vanilla JS's `addEventListner(evt, handler)` method only allows adding listener to one single HTML element at a time, while jQuery allows adding that to a class of HTML elements `$('comments').on(evt, handler)`.  To write readable and maintainable code, I favored adding a new CSS class "comments-container" in `layouts/_default/comments.html` rather than using JS code to navigate the DOM structure like `form.parentNode.nextSibling`, which can be easily broken in case that some siblings are inserted in between.

        https://github.com/pacollins/hugo-future-imperfect-slim/blob/21d42da01277a9d42730b92b060990cda658c681/assets/js/staticman.js#L96-L104

    - jQuery method `ajax()` replaced with XHR.

        https://github.com/pacollins/hugo-future-imperfect-slim/blob/21d42da01277a9d42730b92b060990cda658c681/assets/js/staticman.js#L35-L49

    - jQuery method `serialize()` for converting form data to URL encoded string replaced with JSON-friendly string.

        https://github.com/pacollins/hugo-future-imperfect-slim/blob/21d42da01277a9d42730b92b060990cda658c681/assets/js/staticman.js#L17-L32

        I've hard-coded numerical values `6`, `7` and `11` representing the length of `fields`, `options` and `reCaptcha][` respectively for substring extraction from form input fields' name like `fields[email]` and `options[reCaptcha][siteKey]`.  The goal is to construct a JSON-friendly string like eduardoboucas/staticman#412.

    - replaced all instances of `var` to `let` to limit the scope of the variables to inside the function only: to avoid the following variables, espacially `url` and `api`, from overwriting variables in other files with the same name.

        https://github.com/pacollins/hugo-future-imperfect-slim/blob/21d42da01277a9d42730b92b060990cda658c681/assets/js/staticman.js#L9-L15

## Motivation and Context

It's motivated by the goal to replace jQuery with Vanilla in https://github.com/pacollins/hugo-future-imperfect-slim/issues/231#issuecomment-794723933.  This resolves #242 and resolves #243.

## Screenshots (if appropriate):

[You can use `Windows+Shift+S` or `Control+Command+Shift+4` to add a screenshot to your clipboard and then paste it here.]

## Example

- demo site: https://vincenttam.frama.io/fish-demo/
- source: https://framagit.org/VincentTam/fish-demo
- GitLab bot's commit: https://framagit.org/VincentTam/fish-demo/-/commit/d851332

## Checklist:

- [ ] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [ ] I have updated the `theme.toml`, as applicable.

## Critique

The JS code is repetitive.  From an OO point of view, directly changing the state of the HTML element should give more concise JS code, and the l10n of button texts can be stored in CSS files.  I'm not sure if `{{ i18n ... }}` can be called in `assets/css/*.css`.  Even though that's possible, Hugo experts might prefer putting UI text in the Go-HTML template `layout/**/*.html`.

https://github.com/pacollins/hugo-future-imperfect-slim/blob/21d42da01277a9d42730b92b060990cda658c681/assets/js/staticman.js#L66-L78