### PR TITLE
Fix removeBlur placement

### DIFF
--- a/layouts/_default/featured.html
+++ b/layouts/_default/featured.html
@@ -2,11 +2,15 @@
   {{- $src := "" -}}
   {{- $alt := "" -}}
   {{- $stretch := .Site.Params.imageStretch -}}
+  {{- $blur := .Site.Params.removeBlur -}}
   {{- if .Params.featured -}}
     {{- $src = (path.Join "img" (cond (eq .Params.featuredpath "date") (.Page.Date.Format "2006/01") (.Params.featuredpath)) .Params.featured) | absURL -}}
     {{- $alt = .Params.featuredalt -}}
     {{- with .Params.featuredstretch -}}
       {{- $stretch = . -}}
+    {{- end -}}
+    {{- with .Params.removeBlur -}}
+      {{- $blur = . -}}
     {{- end -}}
   {{- else if .Params.images -}}
     {{- range first 1 .Params.images -}}
@@ -15,9 +19,12 @@
       {{- with .stretch -}}
         {{- $stretch = . -}}
       {{- end -}}
+      {{- with .removeBlur -}}
+        {{- $blur = . -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
-  <a href="{{ $.Page.RelPermalink }}" class="image"{{ if not (.Params.removeBlur | default .Site.Params.removeBlur) }} style="--bg-image: url('{{ $src }}');"{{ end }}>
+  <a href="{{ $.Page.RelPermalink }}" class="image"{{ if not ($blur) }} style="--bg-image: url('{{ $src }}');"{{ end }}>
     <img {{ with $stretch }}class="{{ if or (eq (lower .) "vertical") (eq (lower .) "v") }}stretchV{{ else if or (eq (lower .) "horizontal") (eq (lower .) "h") }}stretchH{{ else if or (eq (lower .) "cover") (eq (lower .) "c") }}cover{{ end }}" {{ end }}src="{{ $src }}" alt="{{ $alt }}">
   </a>
 {{- end -}}


### PR DESCRIPTION
## Description

Allow more control of `removeBlur` by allowing it for individual images within the array as well as legacy `featured`.

```
featuredpath = "img/main/logo.jpg"
featuredalt = "Fox"
featuredstetch = "Vertical"
removeBlur = true
```

```

[[images]]
  src = "img/main/logo.jpg"
  alt = "Fox"
  stretch = "Vertical"
  removeBlur = true
```

## Motivation and Context

#248 

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/11359433/116763553-d1f78380-a9eb-11eb-9ad3-98c616de4286.png)

## Checklist:

- [ ] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [X] I have updated the `theme.toml`, as applicable.
