### PR TITLE
fix: missing staticman in assets.json?

### DIFF
--- a/assets/assets.json
+++ b/assets/assets.json
@@ -10,6 +10,7 @@
       "js/jquery-3.5.1.js",
       "js/fancybox.js",
       "js/lunr.js",
-      "js/util.js"
+      "js/util.js",
+      "js/staticman.js"
    ]
 }


### PR DESCRIPTION
from Riccardo Fusari's email

## Description

Absence of `js/staticman.js` in `assets/assets.json`.

https://github.com/pacollins/hugo-future-imperfect-slim/blob/d2603d7e80174cc83157c03fd6af7f6ae151d80e/assets/assets.json#L9-L14

## Motivation and Context

I'm not 100% sure if this has to be added to the array of `scripts`.  This suggestion comes from Riccardo Fusari's email.

## Screenshots (if appropriate):

[You can use `Windows+Shift+S` or `Control+Command+Shift+4` to add a screenshot to your clipboard and then paste it here.]

## Checklist:

- [ ] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [ ] I have updated the `theme.toml`, as applicable.
