### PR TITLE
fix: remove undefined variable in staticman.js

### DIFF
--- a/assets/js/staticman.js
+++ b/assets/js/staticman.js
@@ -42,7 +42,7 @@
           if (status >= 200 && status < 400) {
             formSubmitted();
           } else {
-            formError(err);
+            formError();
           }
         }
       };
@@ -57,8 +57,7 @@
       form.classList.remove('loading');
     }
 
-    function formError(err) {
-      console.log(err);
+    function formError() {
       showAlert('failed');
       form.classList.remove('loading');
     }


### PR DESCRIPTION
## Description

The `err` variable in the current Staticman JS script is *undefined*, as my correspondence with Ricardo Fusari reveals.

## Motivation and Context

The error-handling function with the `error` argument comes from jQuery's `ajax()` method.  Due to @pacollins' plan to remove jQuery from the dependencies, I submitted #245 to refactor the form submission using XHR objects.

To log XHR errors, one may use `myXHRobj.addEventListener('error', handleEvent)` with custom JS function `handleEvent()`.  As far as I know, few users would interest

```js
function handleEvent {
  console.error(`${e.type}`);
  // render localized error message in HTML
}
```

Interested tech guys would find a way to get errors.  Others might hardly need this `err` object

## Screenshots (if appropriate):

[You can use `Windows+Shift+S` or `Control+Command+Shift+4` to add a screenshot to your clipboard and then paste it here.]

## Checklist:

- [ ] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [ ] I have updated the `theme.toml`, as applicable.
