### PR TITLE
fix: replace staticman form submit with button click

### DIFF
--- a/assets/js/staticman.js
+++ b/assets/js/staticman.js
@@ -76,7 +76,6 @@
     // empty all text & hidden fields but not options
     function clearForm() {
       resetReplyTarget();
-      console.log('test');
       form.querySelector('.submit-notice').classList.remove('submit-success'); // IE10 compatibility
       form.querySelector('.submit-notice').classList.remove('submit-failed');
       form.querySelector('.submit-success').classList.add('hidden'); // hide submission status

--- a/assets/js/staticman.js
+++ b/assets/js/staticman.js
@@ -31,7 +31,6 @@
       });
       let formData = JSON.stringify(xhrObj);  // some API don't accept FormData objects
 
-
       let xhr = new XMLHttpRequest();
       xhr.open('POST', url);
       xhr.setRequestHeader('Content-Type', 'application/json;charset=UTF-8');
@@ -47,8 +46,6 @@
         }
       };
       xhr.send(formData);
-
-      return false;
     });
 
     function formSubmitted() {

--- a/assets/js/staticman.js
+++ b/assets/js/staticman.js
@@ -1,10 +1,10 @@
 (function() {
   let form = document.querySelector('.new-comment');
   if (form) {
-    form.addEventListener('submit', function () {
+    form.querySelector('#comment-form-submit').addEventListener('click', function () {
       form.classList.add('loading');
-      form.querySelector('input[type="submit"]:enabled').classList.add('hidden'); // hide "submit"
-      form.querySelector('input[type="submit"]:disabled').classList.remove('hidden'); // show "submitted"
+      form.querySelector('#comment-form-submit').classList.add('hidden'); // hide "submit"
+      form.querySelector('#comment-form-submitted').classList.remove('hidden'); // show "submitted"
 
       // Construct form action URL form JS to avoid spam
       let api = '{{ .api }}';
@@ -72,8 +72,8 @@
         form.querySelector('.submit-success').classList.add('hidden'); // hide submit success message
         form.querySelector('.submit-failed').classList.remove('hidden');  // show submit failed message
       }
-      form.querySelector('input[type="submit"]:enabled').classList.remove('hidden'); // show "submit"
-      form.querySelector('input[type="submit"]:disabled').classList.add('hidden');  // hide "submitted"
+      form.querySelector('#comment-form-submit').classList.remove('hidden'); // show "submit"
+      form.querySelector('#comment-form-submitted').classList.add('hidden');  // hide "submitted"
     }
 
     // empty all text & hidden fields but not options
@@ -116,6 +116,6 @@
     form.querySelector('.reply-close-btn').addEventListener('click', resetReplyTarget);
 
     // clear form when reset button is clicked
-    form.querySelector('input[type="reset"]').addEventListener('click', clearForm);
+    form.querySelector('#comment-form-reset').addEventListener('click', clearForm);
   }
 })();

--- a/assets/js/staticman.js
+++ b/assets/js/staticman.js
@@ -76,8 +76,9 @@
     // empty all text & hidden fields but not options
     function clearForm() {
       resetReplyTarget();
-      form.querySelector('.submit-notice').classList.remove('.submit-success'); // IE10 compatibility
-      form.querySelector('.submit-notice').classList.remove('.submit-failed');
+      console.log('test');
+      form.querySelector('.submit-notice').classList.remove('submit-success'); // IE10 compatibility
+      form.querySelector('.submit-notice').classList.remove('submit-failed');
       form.querySelector('.submit-success').classList.add('hidden'); // hide submission status
       form.querySelector('.submit-failed').classList.add('hidden'); // hide submission status
     }

--- a/assets/js/staticman.js
+++ b/assets/js/staticman.js
@@ -61,11 +61,9 @@
 
     function showAlert(msg) {
       if (msg == 'success') {
-        form.querySelector('.submit-notice').classList.add('submit-success')
         form.querySelector('.submit-success').classList.remove('hidden');  // show submit success message
         form.querySelector('.submit-failed').classList.add('hidden'); // hide submit failed message
       } else {
-        form.querySelector('.submit-notice').classList.add('submit-failed')
         form.querySelector('.submit-success').classList.add('hidden'); // hide submit success message
         form.querySelector('.submit-failed').classList.remove('hidden');  // show submit failed message
       }
@@ -76,8 +74,6 @@
     // empty all text & hidden fields but not options
     function clearForm() {
       resetReplyTarget();
-      form.querySelector('.submit-notice').classList.remove('submit-success'); // IE10 compatibility
-      form.querySelector('.submit-notice').classList.remove('submit-failed');
       form.querySelector('.submit-success').classList.add('hidden'); // hide submission status
       form.querySelector('.submit-failed').classList.add('hidden'); // hide submission status
     }

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -411,6 +411,12 @@ input[type="button"],
   }
 }
 
+button[type="button"] {
+  width: 100%;
+  margin: 0.25em 0;
+  padding: 0 1em;
+}
+
 label {
   color: $header-color;
   display: block;

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -411,7 +411,8 @@ input[type="button"],
   }
 }
 
-button[type="button"] {
+button[type="button"],
+button[type="reset"] {
   width: 100%;
   margin: 0.25em 0;
   padding: 0 1em;

--- a/layouts/_default/comments.html
+++ b/layouts/_default/comments.html
@@ -59,7 +59,7 @@
           {{/* Form buttons */}}
           <button type='button' id="comment-form-submit" class='button'>{{ i18n "submit" }}</button>
           <button type='button' id="comment-form-submitted" class='hidden button' disabled>{{ i18n "submitted" }}</button>
-          <button type='button' id="comment-form-reset" class='button'>{{ i18n "reset" }}</button>
+          <button type='reset' id="comment-form-reset" class='button'>{{ i18n "reset" }}</button>
         </form>
     </div>
 

--- a/layouts/_default/comments.html
+++ b/layouts/_default/comments.html
@@ -57,9 +57,9 @@
           </div>
 
           {{/* Form buttons */}}
-          <input type='submit' value='{{ i18n "submit" }}' class='button'>
-          <input type='submit' value='{{ i18n "submitted" }}' class='hidden button' disabled>
-          <input type='reset' value='{{ i18n "reset" }}' class='button'>
+          <button type='button' id="comment-form-submit" class='button'>{{ i18n "submit" }}</button>
+          <button type='button' id="comment-form-submitted" class='hidden button' disabled>{{ i18n "submitted" }}</button>
+          <button type='button' id="comment-form-reset" class='button'>{{ i18n "reset" }}</button>
         </form>
     </div>
 


### PR DESCRIPTION
## Description

A basic attempt to fix the "405 Not Allowed error" observed in https://github.com/pacollins/hugo-future-imperfect-slim/pull/256#issuecomment-853911571.

Changes:

1. HTML template: refactor `<input type="submit" ...>` into `<button type="button" id="commit-form-submit" ...>`.
2. JS script:
    1. listen to submit button click event instead of form submit event
    2. update DOM query selectors to match HTML template code change

## Motivation and Context

Thanks to my correspondence with Riccardo Fusari, I realised that my Vanilla Staticman JS script in #245 introduced the above 405 error, which blocks the transfer of the POST request to the Staticman API instance, as well as a NS_BINDING_ERROR during form submission in local tests.

I tried again and again this weekend with no success, so I'm giving up on listening to form submission event.  Here's a Stack Overflow answers that inspired this PR:
https://stackoverflow.com/a/66496937

## Screenshots (if appropriate):

The error screenshot can be found in the linked issue <span>#</span>256.

Successful example:

![server-response-success](https://user-images.githubusercontent.com/5748535/120998342-4d391b80-c788-11eb-97ce-314ca583e32e.png)
![submit-btn-binding](https://user-images.githubusercontent.com/5748535/120998352-4f9b7580-c788-11eb-9767-9a29998e5d79.png)

You may view PR VincentTam#6 to the source branch (with GitHub Actions added and some necessary config) of demo site `addGHCI` for an example of successful form submission.

## Checklist:

- [ ] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [ ] I have updated the `theme.toml`, as applicable.
