### PR TITLE
Improve sharing buttons appearance

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -28,6 +28,7 @@ disableLanguages        = []
   imageStretch          = ""
   removeBlur            = false
   socialShare           = ["twitter", "facebook", "reddit", "linkedin", "pinterest", "email"]
+  shareFromPost         = true
   hideEmptyStats        = false
 
   [params.meta]

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -40,7 +40,7 @@
 [read_more]
   other = "Read More"
 [share_post]
-  other = "Share This Post"
+  other = "Share Post"
 [check_out]
   other = "Check out this post by"
 [say_something]

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,13 +2,15 @@
   <article>
     <div class="post">
       {{ .Render "header" }}
-      <div id="socnet-share">
-        {{ partial "share-buttons" . }}
-      </div>
       <div class="content">
         {{ .Render "featured" }}
         {{ .Content }}
       </div>
+      {{ if .Site.Params.shareFromPost }}
+      <div id="socnet-share">
+        <h4>{{ i18n "share_post" }}:</h4>{{ partial "share-buttons" . }}
+      </div>
+      {{ end }}
       <footer>
         {{ .Render "stats" }}
       </footer>

--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -37,7 +37,7 @@
   {{ if .Site.Params.header.languageMenu }}{{ partial "language-menu" . }}{{ end }}
   {{ if .Site.Params.header.shareMenu }}
     <menu id="share-menu" class="flyout-menu menu">
-      <h1>Share Post</h1>
+      <h1>{{ i18n "share_post" }}</h1>
       {{ partial "share-buttons" . }}
     </menu>
   {{ end }}


### PR DESCRIPTION
## Description

1. Use i18n title for share menu Update translation to match current view
2. Make sharing from post body controlled separately from header menu
3. Move sharing buttons to the bottom of the post and add title to make it clear it's sharing

## Motivation and Context

It was impossible to enable sharing from the main menu, but disable in the post.
Buttons in the post don't really match the light style of the theme, they're quite big and better be placed below the main content.

## Screenshots (if appropriate):

The buttons are the same, but I'm not the expert in html/css. Maybe it's better to redesign them completely and make less obtrusive (e.g see reddit, it has a single small nice share button with pop-up menu).
Feel free to reach out to me in [telegram](t.me/fo2rist) if you want to discuss any of PRs in real-time

## Checklist:

- [ ] I have updated the [documentation](https://github.com/pacollins/hugo-future-imperfect-slim/wiki), as applicable.
- [ ] I have updated the `theme.toml`, as applicable.
